### PR TITLE
Add microrb.com.

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
 
   * [The Ruby Toolbox](https://www.ruby-toolbox.com/)
   * [RubyGems](https://www.rubygems.org)
+  * [microrb.com](http://microrb.com/)
 
 ## People to Follow
 


### PR DESCRIPTION
> micro.rb aims at gathering small well focused ruby libraries,
> that do one thing and do it well. We are concerned about focus and clarity.
> Other metrics such as the number of dependencies and the lines of code also matter.
