### PR TITLE
Add chruby, ruby-install, and ruby-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,11 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
 ## Environment Management
 
 *Libraries for Ruby version and environment management.*
+  * [chruby](https://github.com/postmodern/chruby) - Changes the current Ruby
   * [rvm](https://rvm.io/) - Ruby Version Manager
   * [rbenv](http://rbenv.org/) - Groom your app’s Ruby environment
+  * [ruby-install](https://github.com/postmodern/ruby-install) - Installs Ruby, JRuby, Rubinius, MagLev or MRuby
+  * [ruby-build](https://github.com/sstephenson/ruby-build) - Compile and install Ruby
 
 ## Error Handling
 


### PR DESCRIPTION
These are all popular alternatives or complements to rbenv and rvm.
