### PR TITLE
Add Web Framework: Pakyow.

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
   * [Padrino](http://www.padrinorb.com/) - The Godfather of Sinatra provides a full-stack agnostic framework on top of Sinatra
   * [Cramp](http://cramp.in/) - Cramp is a fully asynchronous real-time web application framework in Ruby
   * [Lotus](http://lotusrb.org/) - A newborn complete Ruby web framework that is simple, fast and lightweight.
+  * [Pakyow](http://pakyow.com/) - Pakyow is an open-source framework for the modern web. Build working software faster with a development process that remains friendly to both designers and developers. It's built for getting along.
 
 
 ## RESTful API


### PR DESCRIPTION
> Pakyow is an open-source framework for the modern web. Build working software faster with a development process that remains friendly to both designers and developers. It's built for getting along.
