### PR TITLE
Add Web Framework: Cuba.

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
   * [Padrino](http://www.padrinorb.com/) - The Godfather of Sinatra provides a full-stack agnostic framework on top of Sinatra
   * [Cramp](http://cramp.in/) - Cramp is a fully asynchronous real-time web application framework in Ruby
   * [Lotus](http://lotusrb.org/) - A newborn complete Ruby web framework that is simple, fast and lightweight.
+  * [Cuba](http://cuba.is/) - Cuba is a microframework for web development originally inspired by Rum, a tiny but powerful mapper for Rack applications.
 
 
 ## RESTful API


### PR DESCRIPTION
> Cuba is a microframework for web development originally inspired by Rum, a tiny but powerful mapper for Rack applications.
