### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
 
 *Libraries for administrative interfaces.*
 
-  * [active_admin](https://github.com/gregbell/active_admin) The administration framework for Ruby on Rails applications
+  * [active_admin](https://github.com/activeadmin/activeadmin) The administration framework for Ruby on Rails applications
   * [rails_admin](https://github.com/sferik/rails_admin) A Rails engine that provides an easy-to-use interface for managing your data
 
 ## Anti-spam
@@ -141,13 +141,13 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
 
 *Content management systems*
 
-  * [Refinery](http://refinerycms.com/) An extendable Ruby on Rails CMS that supports Rails 3.2 and 4
+  * [Refinery](http://www.refinerycms.com) An extendable Ruby on Rails CMS that supports Rails 3.2 and 4
   * [Comfortable Mexican Sofa](https://github.com/comfy/comfortable-mexican-sofa) A powerful Rails 4 CMS Engine
   * [Browser](http://www.browsercms.org/) Humane Content Management for Rails
   * [Locomotive](http://www.locomotivecms.com/) a brand new CMS system with super sexy UI and cool features
   * [Radiant](http://radiantcms.org/) A no-fluff, open source content management system
   * [Nesta](http://nestacms.com/) A lightweight CMS, implemented in Sinatra
-  * [alchemy_cms](https://github.com/magiclabs/alchemy_cms) the most powerful, user friendly and flexible Rails CMS
+  * [alchemy_cms](https://github.com/AlchemyCMS/alchemy_cms) the most powerful, user friendly and flexible Rails CMS
   * [weby](https://github.com/cercomp/weby) Newbie CMS in Ruby on Rails
 
 ## Code Analysis and Linter
@@ -198,7 +198,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
 *Libraties for connecting and operating databases.*
 
   * Relational Databases
-    * [ruby-pg](https://bitbucket.org/ged/ruby-pg) Ruby interface to the PostgreSQL >= 8.4
+    * [ruby-pg](https://bitbucket.org/ged/ruby-pg/wiki/Home) Ruby interface to the PostgreSQL >= 8.4
     * [mysql2](https://github.com/brianmario/mysql2) A modern, simple and very fast Mysql library for Ruby
     * [sqlite3-ruby](https://github.com/sparklemotion/sqlite3-ruby) Ruby bindings for the SQLite3 embedded database
 
@@ -223,9 +223,9 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
 *Software and libraries for DevOps.*
 
   * [Puppet](https://github.com/puppetlabs/puppet) - Server automation framework and application
-  * [Chef](https://github.com/opscode/chef) - A systems integration framework, built to bring the benefits of configuration management to your entire infrastructure.
-  * [Vagrant](http://www.vagrantup.com) - Vagrant is a tool for building and distributing development environments.
-  * [Capistrano](http://www.capistranorb.com) - Remote multi-server automation tool
+  * [Chef](https://github.com/chef/chef) - A systems integration framework, built to bring the benefits of configuration management to your entire infrastructure.
+  * [Vagrant](https://www.vagrantup.com/) - Vagrant is a tool for building and distributing development environments.
+  * [Capistrano](http://capistranorb.com/) - Remote multi-server automation tool
   * [Mina](https://github.com/mina-deploy/mina) Really fast deployer and server automation tool
 
 ## Distribution
@@ -247,7 +247,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
 
 ## E-Commerce & Online Paying
 
-  * [Active Merchant](https://github.com/Shopify/active_merchant) - A simple payment abstraction library extracted from Shopify.
+  * [Active Merchant](https://github.com/activemerchant/active_merchant) - A simple payment abstraction library extracted from Shopify.
   * [Spree](https://github.com/spree/spree) - A complete open source e-commerce solution for Ruby on Rails.
   * [PayPal Merchant SDK](https://github.com/paypal/merchant-sdk-ruby) - Provides Ruby APIs for processing payments, recurring payments, subscriptions and transactions using PayPal's Merchant APIs.
 
@@ -256,7 +256,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
 *Libraries for sending and parsing email.*
 
   * [mail](https://github.com/mikel/mail) A Really Ruby Mail Library
-  * [mailman](https://github.com/titanous/mailman) An incoming mail processing microframework in Ruby
+  * [mailman](https://github.com/mailman/mailman) An incoming mail processing microframework in Ruby
 
 ## Environment Management
 
@@ -310,7 +310,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
 
 *Awesome game development libraries.*
 
-  * [Gosu](http://www.libgosu.org) - A 2D game development library for the Ruby and C++ programming languages
+  * [Gosu](https://www.libgosu.org/) - A 2D game development library for the Ruby and C++ programming languages
 
 
 ## Geolocation
@@ -338,13 +338,13 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
 *Libraries for making Ruby faster.*
 
   * [EventMachine](https://github.com/eventmachine/eventmachine) - EventMachine: fast, simple event-processing library for Ruby programs
-  * [Celluloid](http://celluloid.io) - Actor-based concurrent object framework for Ruby
+  * [Celluloid](https://celluloid.io/) - Actor-based concurrent object framework for Ruby
 
 ## HTML/XML/CSS Manipulation
 
 *Libraries for working with HTML, XML & CSS.*
 
-  * [Nokogiri](http://nokogiri.org)
+  * [Nokogiri](http://www.nokogiri.org/)
   * [loofah](https://github.com/flavorjones/loofah) A general library for manipulating and transforming HTML/XML documents and fragments
 
 ## HTTP
@@ -353,7 +353,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
 
   * [httparty](https://github.com/jnunemaker/httparty) Makes http fun again!
   * [faraday](https://github.com/lostisland/faraday) Simple, but flexible HTTP client library, with support for multiple backends.
-  * [http](https://github.com/tarcieri/http) A simple Ruby DSL for making HTTP requests
+  * [http](https://github.com/httprb/http) A simple Ruby DSL for making HTTP requests
   * [excon](https://github.com/excon/excon) Usable, fast, simple HTTP(S) 1.1 for Ruby
   * [nestful](https://github.com/maccman/nestful) Simple Ruby HTTP/REST client with a sane API
 
@@ -379,7 +379,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
 
 *Libraries for generating and working with log files.*
 
-  * [Logstash](https://github.com/elasticsearch/logstash) Logstash is a tool for managing events and logs.
+  * [Logstash](https://github.com/elastic/logstash) Logstash is a tool for managing events and logs.
 
 ## Machine Learning
 
@@ -486,7 +486,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
   * [spreadsheet](https://github.com/zdavatz/spreadsheet) - The Spreadsheet Library is designed to read and write Spreadsheet Documents.
   * [axlsx](https://github.com/randym/axlsx) - Axlsx excels at helping you generate beautiful Office Open XML Spreadsheet documents.
   * [axlsx_rails](https://github.com/straydogstudio/axlsx_rails) - Axlsx_Rails provides an Axlsx renderer so you can move all your spreadsheet code from your controller into view files. 
-  * [roo](https://github.com/Empact/roo) - Roo implements read access for all spreadsheet types and read/write access for Google spreadsheets.
+  * [roo](https://github.com/roo-rb/roo) - Roo implements read access for all spreadsheet types and read/write access for Google spreadsheets.
   * [google-spreadsheet-ruby](https://github.com/gimite/google-spreadsheet-ruby) - This is a library to read/write Google Spreadsheet.
   * [rubyXL](https://github.com/weshatheleopard/rubyXL) - rubyXL is a gem which allows the parsing, creation, and manipulation of Microsoft Excel (.xlsx/.xlsm) Documents
   * [Odf-report](https://github.com/sandrods/odf-report) - Generates ODF files, given a template (.odt) and data, replacing tags
@@ -520,7 +520,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
 *Libraries and software for indexing and performing search queries on data.*
 
   * [Thinking Sphinx](https://github.com/pat/thinking-sphinx) - Sphinx plugin for ActiveRecord/Rails
-  * [elasticsearch-ruby](https://github.com/elasticsearch/elasticsearch-ruby) - Ruby integrations for Elasticsearch
+  * [elasticsearch-ruby](https://github.com/elastic/elasticsearch-ruby) - Ruby integrations for Elasticsearch
   * [Searchkick](https://github.com/ankane/searchkick) - Intelligent search made easy
   * [PgSearch](https://github.com/Casecommons/pg_search) - PostgreSQL's full text search
   * [Rroonga](https://github.com/ranguba/rroonga) - The Ruby bindings of Groonga
@@ -587,7 +587,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
     * [MiniTest](https://github.com/seattlerb/minitest) - minitest provides a complete suite of testing facilities supporting TDD, BDD, mocking, and benchmarking
     * [Cucumber]
        * [Cucumber Github](https://github.com/cucumber/cucumber/wiki) - Cucumber is a tool that executes plain-text functional descriptions as automated tests
-       * [Cucumber Site](http://cukes.info/) - Behaviour Driven Development with elegacy and joy
+       * [Cucumber Site](https://cucumber.io/) - Behaviour Driven Development with elegacy and joy
     * [Spinach](https://github.com/codegram/spinach) - Spinach is a high-level BDD framework that leverages the expressive Gherkin language (used by Cucumber) to help you define executable specifications of your application or library's acceptance criteria.
     * [Rubytest](http://rubyworks.github.io/rubytest) - Rubytest is a testing metaframework usedful for create highly customize test suites or building whole new test frameworks.
        * [BRASS](http://rubyworks.github.io/brass) - Bare-metal Ruby assertion system standard used by Rubytest.
@@ -600,7 +600,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
     * [FlexMock](https://github.com/jimweirich/flexmock) - Flexible mocking for Ruby testing
   * Fake Data
     * [Faker](https://github.com/stympy/faker) - A library for generating fake data such as names, addresses, and phone numbers
-    * [ffaker](https://github.com/emmanueloga/ffaker) - Faker Refactored.
+    * [ffaker](https://github.com/ffaker/ffaker) - Faker Refactored.
     * [Forgery](https://github.com/sevenwire/forgery) - Easy and customizable generation of forged data.
   * Code Coverage
     * [simplecov](https://github.com/colszowka/simplecov) Code coverage for Ruby 1.9+ with a powerful configuration library and automatic merging of coverage
@@ -658,7 +658,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
   * [Cramp](http://cramp.in/) - Cramp is a fully asynchronous real-time web application framework in Ruby
   * [Lotus](http://lotusrb.org/) - A newborn complete Ruby web framework that is simple, fast and lightweight.
   * [Cuba](http://cuba.is/) - Cuba is a microframework for web development originally inspired by Rum, a tiny but powerful mapper for Rack applications.
-  * [Pakyow](http://pakyow.com/) - Pakyow is an open-source framework for the modern web. Build working software faster with a development process that remains friendly to both designers and developers. It's built for getting along.
+  * [Pakyow](https://pakyow.com/) - Pakyow is an open-source framework for the modern web. Build working software faster with a development process that remains friendly to both designers and developers. It's built for getting along.
 
 ## Web Servers
 
@@ -669,7 +669,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
   * [trinidad](https://github.com/trinidad/trinidad) Run Rails or Rack applications within an embedded Apache Tomcat container.
   * [unicorn](https://github.com/defunkt/unicorn) An HTTP server for Rack applications designed to only serve fast clients.
   * [passenger](https://github.com/phusion/passenger) A modern web server and application server for Ruby, Python and Node.js.
-  * [pow](https://github.com/37signals/pow) Pow treats files and directories as ruby objects giving you more power and flexibility.
+  * [pow](https://github.com/basecamp/pow) Pow treats files and directories as ruby objects giving you more power and flexibility.
   * [goliath](https://github.com/postrank-labs/goliath) is a non-blocking Ruby web server framework.
 
 ## WebSocket
@@ -690,10 +690,10 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
   * [cinch](https://github.com/cinchrb/cinch) The IRC Bot Building Framework
   * [pry](https://github.com/pry/pry) An IRB alternative and runtime developer console
   * [friendly_id](https://github.com/norman/friendly_id) Slugging and permalink plugins for ActiveRecord
-  * [backup](https://github.com/meskyanichi/backup) An elegant DSL in Ruby for performing backups on UNIX-like systems
+  * [backup](https://github.com/backup/backup) An elegant DSL in Ruby for performing backups on UNIX-like systems
   * [kss](https://github.com/kneath/kss) Documenting CSS and generating styleguides
   * [AASM](https://github.com/aasm/aasm) - A library for adding finite state machines to Ruby classes
-  * [JsonCompare](https://github.com/a2design-company/json-compare) - Returns the difference between two JSON files
+  * [JsonCompare](https://github.com/a2design-inc/json-compare) - Returns the difference between two JSON files
   * [blankable](https://github.com/lab2023/blankable) - Adds blank slates to index view in Rails
   * [tcmb_currency](https://github.com/lab2023/tcmb_currency) - T.C.M.B. currencies for Money Gem
   * [enumerize](https://github.com/brainspec/enumerize) - Enumerated attributes with I18n and ActiveRecord/Mongoid support
@@ -717,10 +717,10 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
 *Where to discover things (libraries, news e.g) about Ruby.*
 
   * [The Ruby Toolbox](https://www.ruby-toolbox.com/)
-  * [RubyGems](https://www.rubygems.org)
+  * [RubyGems](https://rubygems.org/)
   * [RubyDaily](http://rubydaily.org) - Community driven news
   * [Ruby Weekly](http://rubyweekly.com/) - A free, once–weekly e-mail round-up of Ruby news and articles.
-  * [Ruby5](http://ruby5.envylabs.com/) - The latest news in the Ruby and Rails community
+  * [Ruby5](https://ruby5.codeschool.com/) - The latest news in the Ruby and Rails community
   * [RubyFlow](http://www.rubyflow.com) - Ruby Programming Community Link Blog
   * [GemBundle](http://www.gembundle.com) - A place to discover new Ruby Gems
 

--- a/README.md
+++ b/README.md
@@ -1,742 +1,1115 @@
-# Awesome Ruby
+# <img src="https://raw.githubusercontent.com/markets/awesome-ruby/gh-pages/images/logo.png" align="absmiddle"/> <a href="http://awesome-ruby.com">Awesome Ruby</a> [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
-A curated list of awesome Ruby frameworks, libraries and resources. Inspired by [awesome-php](https://github.com/ziadoz/awesome-php) & [awesome-python](https://github.com/vinta/awesome-python).
+A categorized community-driven collection of awesome Ruby libraries, tools, frameworks and software. The essential Ruby to build modern Apps and Web Apps.
 
-## Contribution
+Sharing, suggestions and contributions are always welcome! Please take a look at the [contribution guidelines and quality standard](https://github.com/markets/awesome-ruby/blob/master/CONTRIBUTING.md) first.
 
-Your Pull requests are welcome! Let's make this the awesomest resource for Ruby :purple_heart:
+Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/contributors), you're awesome and wouldn't be possible without you!
 
-- [Awesome Ruby](#awesome-ruby)
-  - [Admin Panels](#admin-panels)
-  - [Anti-spam](#anti-spam)
-  - [Asset Management](#asset-management)
-  - [Audio](#audio)
-  - [Authentication and OAuth](#authentication-and-oauth)
-  - [Build Tools](#build-tools)
-  - [Caching](#caching)
-  - [Cloud Services](#cloud-services)
-  - [CMS](#cms)
-  - [Code Analysis and Linter](#code-analysis-and-linter)
-  - [Command-line Tools](#command-line-tools)
-  - [Configuration](#configuration)
-  - [CSS and Styling](#css-and-styling)
-  - [Data Validation](#data-validation)
-  - [Data Visualization](#data-visualization)
-  - [Database Drivers](#database-drivers)
-  - [Date and Time](#date-and-time)
-  - [Debugging Tools](#debugging-tools)
-  - [DevOps Tools](#devops-tools)
-  - [Distribution](#distribution)
-  - [Documentation](#documentation)
-  - [Downloader](#downloader)
-  - [E-Commerce & Online Paying](#e-commerce-&-online-paying)
-  - [E-Mail](#email)
-  - [Environment Management](#environment-management)
-  - [File Uploading](#file-uploading)
-  - [Feature Flipping] (#feature-flipping)
-  - [Foreign Function Interface](#foreign-function-interface)
-  - [Forms](#forms)
-  - [Game Development](#game-development)
-  - [Geolocation](#geolocation)
-  - [GUI](#gui)
-  - [High Performance](#high-performance)
-  - [HTML/XML/CSS Manipulation](#htmlxmlcss-manipulation)
-  - [HTTP](#http)
-  - [Imagery](#imagery)
-  - [Internationalization](#internationalization)
-  - [Logging](#logging)
-  - [Machine Learning](#machine-learning)
-  - [MapReduce](#mapreduce)
-  - [Natural Language Processing](#natural-language-processing)
-  - [Networking](#networking)
-  - [ORM](#orm)
-  - [Package Management](#package-management)
-  - [Presentation Tools](#presentation-tools)
-  - [Processes and Threads](#processes-and-threads)
-  - [Push Notification](#push-notification)
-  - [Queue](#queue)
-  - [Spreadsheets](#spreadsheets)
-  - [RESTful API](#restful-api)
-  - [Science and Data Analysis](#science-and-data-analysis)
-  - [Search](#search)
-  - [Site Monitoring](#site-monitoring)
-  - [Starter Apps](#starter-apps)
-  - [Tagging](#tagging)
-  - [Template Engine](#template-engine)
-  - [Testing](#testing)
-  - [Text Processing](#text-processing)
-  - [Third-party APIs](#third-party-apis)
-  - [URL Manipulation](#url-manipulation)
-  - [Video](#video)
-  - [Web Content Extracting](#web-content-extracting)
-  - [Web Crawling](#web-crawling)
-  - [Web Frameworks](#web-frameworks)
-  - [Web Servers](#web-servers)
-  - [WebSocket](#websocket)
-- [Miscellaneous](#miscellaneous)
-  - [Editor Plugins](#editor-plugins)
-- [Resources](#resources)
-  - [People to Follow](#people-to-follow)
-- [Other Awesome Lists](#other-awesome-lists)
-- [Contributing](#contributing)
+* [Awesome Ruby](#awesome-ruby)
+  * [Abstraction](#abstraction)
+  * [A/B Testing](#ab-testing)
+  * [Admin Interface](#admin-interface)
+  * [Analytics](#analytics)
+  * [API Builder](#api-builder)
+  * [Assets](#assets)
+  * [Authentication and OAuth](#authentication-and-oauth)
+  * [Authorization](#authorization)
+  * [Automation](#automation)
+  * [Caching](#caching)
+  * [CLI Builder](#cli-builder)
+  * [CLI Utilities](#cli-utilities)
+  * [Cloud](#cloud)
+  * [CMS](#cms)
+  * [Code Analysis and Metrics](#code-analysis-and-metrics)
+  * [Coding Style Guides](#coding-style-guides)
+  * [Concurrency](#concurrency)
+  * [Configuration](#configuration)
+  * [Core Extensions](#core-extensions)
+  * [Country Data](#country-data)
+  * [CRM](#crm)
+  * [Dashboards](#dashboards)
+  * [Data Processing and ETL](#data-processing-and-etl)
+  * [Data Visualization](#data-visualization)
+  * [Database Drivers](#database-drivers)
+  * [Database Tools](#database-tools)
+  * [Date and Time Processing](#date-and-time-processing)
+  * [Debugging Tools](#debugging-tools)
+  * [Decorators](#decorators)
+  * [DevOps Tools](#devops-tools)
+  * [Documentation](#documentation)
+  * [E-Commerce and Payments](#e-commerce-and-payments)
+  * [Ebook](#ebook)
+  * [Email](#email)
+  * [Encryption](#encryption)
+  * [Environment Management](#environment-management)
+  * [Error Handling](#error-handling)
+  * [File Upload](#file-upload)
+  * [Form Builder](#form-builder)
+  * [Game Development](#game-development)
+  * [Geolocation](#geolocation)
+  * [Git Tools](#git-tools)
+  * [GUI](#gui)
+  * [HTML/XML Parsing](#htmlxml-parsing)
+  * [HTTP](#http)
+  * [Image Processing](#image-processing)
+  * [Implementations/Compilers](#implementationscompilers)
+  * [Internationalization](#internationalization)
+  * [IRB](#irb)
+  * [Logging](#logging)
+  * [Machine Learning](#machine-learning)
+  * [Markdown Processors](#markdown-processors)
+  * [Misc](#misc)
+  * [Mobile Development](#mobile-development)
+  * [Money](#money)
+  * [Music and Sound](#music-and-sound)
+  * [Natural Language Processing](#natural-language-processing)
+  * [Navigation](#navigation)
+  * [ORM/ODM](#ormodm)
+  * [ORM/ODM Extensions](#ormodm-extensions)
+  * [Package Management](#package-management)
+  * [Pagination](#pagination)
+  * [PDF](#pdf)
+  * [Performance Monitoring](#performance-monitoring)
+  * [Presentation Programs](#presentation-programs)
+  * [Process Monitoring](#process-monitoring)
+  * [Processes and Threads](#processes-and-threads)
+  * [Profiler](#profiler)
+  * [Queue](#queue)
+  * [Rails Application Generators](#rails-application-generators)
+  * [Robotics](#robotics)
+  * [RSS](#rss)
+  * [Scheduling](#scheduling)
+  * [Scientific](#scientific)
+  * [Search](#search)
+  * [Security](#security)
+  * [SEO](#seo)
+  * [Social Networking](#social-networking)
+  * [Spreadsheets and Documents](#spreadsheets-and-documents)
+  * [State Machines](#state-machines)
+  * [Static Site Generation](#static-site-generation)
+  * [Template Engine](#template-engine)
+  * [Testing](#testing)
+  * [Third-party APIs](#third-party-apis)
+  * [Video](#video)
+  * [Web Crawling](#web-crawling)
+  * [Web Frameworks](#web-frameworks)
+  * [Web Servers](#web-servers)
+  * [WebSocket](#websocket)
+* [Services and Apps](#services-and-apps)
+* [Resources](#resources)
+* [Other Awesome Lists](#other-awesome-lists)
 
+## Abstraction
 
-## Admin Panels
+* [ActiveInteraction](https://github.com/orgsync/active_interaction) - Manage application specific business logic.
+* [Apotomo](https://github.com/apotonick/apotomo) - Based on Cells, Apotomo gives you widgets and encapsulation, bubbling events, AJAX page updates, rock-solid testing and more.
+* [Cells](https://github.com/apotonick/cells) - View Components for Rails.
+* [Decent Exposure](https://github.com/hashrocket/decent_exposure) - A helper for creating declarative interfaces in controllers.
+* [Interactor](https://github.com/collectiveidea/interactor) - Interactor provides a common interface for performing complex interactions in a single request.
+* [Light Service](https://github.com/adomokos/light-service) - Series of Actions with an emphasis on simplicity.
+* [Mutations](https://github.com/cypriss/mutations) - Compose your business logic into commands that sanitize and validate input.
+* [Responders](https://github.com/plataformatec/responders) -  A set of Rails responders to dry up your application.
+* [Surrounded](https://github.com/saturnflyer/surrounded) - Encapsulated related objects in a single system to add behavior during runtime. Extensible implementation of DCI.
+* [Trailblazer](https://github.com/apotonick/trailblazer) - Trailblazer is a thin layer on top of Rails. It gently enforces encapsulation, an intuitive code structure and gives you an object-oriented architecture.
+* [wisper](https://github.com/krisleech/wisper) - A micro library providing Ruby objects with Publish-Subscribe capabilities.
 
-*Libraries for administrative interfaces.*
+##A/B Testing
 
-  * [active_admin](https://github.com/activeadmin/activeadmin) The administration framework for Ruby on Rails applications
-  * [rails_admin](https://github.com/sferik/rails_admin) A Rails engine that provides an easy-to-use interface for managing your data
+* [Rollout](https://github.com/FetLife/rollout) - Feature flippers.
+* [Split](https://github.com/splitrb/split) - Rack Based AB testing framework.
+* [Vanity](https://github.com/assaf/vanity) - an A/B testing framework for Rails that is datastore agnostic.
 
-## Anti-spam
+## Admin Interface
 
-*Libraries for fighting spam.*
+* [ActiveAdmin](http://activeadmin.info) - A Ruby on Rails framework for creating elegant backends for website administration.
+* [Administrate](https://github.com/thoughtbot/administrate) - A Rails engine that helps you put together a super-flexible admin dashboard, by Thoughtbot.
+* [bhf](http://antpaw.github.io/bhf/) - A simple to use Rails-Engine-Gem that offers an admin interface for trusted user.
+* [RailsAdmin](https://github.com/sferik/rails_admin) - A Rails engine that provides an easy-to-use interface for managing your data.
+* [Typus](https://github.com/typus/typus) - Ruby on Rails control panel to allow trusted users edit structured content.
+* [Upmin Admin](https://github.com/upmin/upmin-admin-ruby) - A framework for creating powerful Ruby on Rails admin backends with minimal effort.
 
-  * [RubySpamAssassin](https://github.com/noeticpenguin/RubySpamAssassin) Kills Spam Dead. Perhaps before it's sent!
+## Analytics
 
-## Asset Management
+* [Ahoy](https://github.com/ankane/ahoy) - A solid foundation to track visits and events in Ruby, JavaScript, and native apps.
+* [Analytical](https://github.com/jkrall/analytical) - Gem for managing multiple analytics services in your rails app.
+* [Gabba](https://github.com/hybridgroup/gabba) - Simple way to send server-side notifications to Google Analytics.
+* [Impressionist](https://github.com/charlotte-ruby/impressionist) - Rails Plugin that tracks impressions and page views.
+* [Legato](https://github.com/tpitale/legato) - Model analytics reports and queries against the official Google Analytics Reporting API.
+* [Rack::Tracker](https://github.com/railslove/rack-tracker) - Rack middleware that can be hooked up to multiple services and exposing them in a unified fashion.
+* [Staccato](https://github.com/tpitale/staccato) - Track analytics into the official Google Analytics Collection API.
 
-*Tools for managing, compressing and minifying website assets.*
+## API Builder
 
-  * [sprockets](https://github.com/sstephenson/sprockets) Rack-based asset packaging system
-  * [rails-assets](https://github.com/rails-assets/rails-assets/) is the frictionless proxy between Bundler and Bower
+* [ActiveModel::Serializers](https://github.com/rails-api/active_model_serializers) - JSON serialization of objects.
+* [Blanket](https://github.com/inf0rmer/blanket) - A dead simple API wrapper.
+* [Crêpe](https://github.com/crepe/crepe) - The thin API stack.
+* [Grape](http://intridea.github.io/grape) - An opinionated micro-framework for creating REST-like APIs in Ruby.
+* [Her](https://github.com/remiprev/her) - an ORM that maps REST resources to Ruby objects. Designed to build applications that are powered by a RESTful API instead of a database.
+* [jbuilder](https://github.com/rails/jbuilder) - Create JSON structures via a Builder-style DSL.
+* [JSONAPI::Resources](https://github.com/cerebris/jsonapi-resources) - JSONAPI::Resources, or "JR", provides a framework for developing a server that complies with the JSON API specification.
+* [Jsonite](https://github.com/crepe/jsonite) - A tiny, HAL-compliant JSON presenter for your APIs.
+* [Pliny](https://github.com/interagent/pliny) - Opinionated template Sinatra app for writing excellent APIs in Ruby.
+* [rabl](https://github.com/nesquena/rabl) - General ruby templating with json, bson, xml, plist and msgpack support.
+* [Rails::API](https://github.com/rails-api/rails-api) - Rails for API only applications.
+* [Roar](https://github.com/apotonick/roar) - Resource-Oriented Architectures in Ruby.
+* [Version Cake](https://github.com/bwillis/versioncake) - An unobtrusive way to version APIs in your Rails app.
+* [versionist](https://github.com/bploetz/versionist) - A plugin for versioning Rails based RESTful APIs.
 
-## Audio
+## Assets
 
-  * [seal](https://github.com/zhangsu/seal) A C library (with Ruby binding) for 3D audio rendering
+* [Compass](https://github.com/Compass/compass) - Compass is a Stylesheet Authoring Environment that makes your website design simpler to implement and easier to maintain.
+* [Emoji](https://github.com/wpeterson/emoji) - Exposes the Phantom Open Emoji library unicode/image assets and APIs for working with them.
+* [Less Rails](https://github.com/metaskills/less-rails) - The dynamic stylesheet language for the Rails asset pipeline.
+* [Less](https://github.com/cowboyd/less.rb) - Leaner CSS, in your browser or Ruby.
+* [Sass](http://sass-lang.com) - Sass makes CSS fun again.
+* Management:
+  * [Asset Sync](https://github.com/AssetSync/asset_sync) - Synchronises Assets between Rails and S3.
+  * [Autoprefixer](https://github.com/ai/autoprefixer-rails) - Parse CSS and add vendor prefixes to rules by Can I Use.
+  * [bower-rails](https://github.com/rharriso/bower-rails) - Bower support for Rails projects.
+  * [Rails Assets](https://rails-assets.org) - Bundler to Bower proxy.
+  * [Sprockets](https://github.com/sstephenson/sprockets) - Rack-based asset packaging system.
+* Development:
+  * [Quiet Assets](https://github.com/evrone/quiet_assets) - Mute assets pipeline log messages.
 
 ## Authentication and OAuth
 
-*Libraries for implementing authentications schemes.*
+* [Authlogic](https://github.com/binarylogic/authlogic) - Authlogic is a clean, simple, and unobtrusive ruby authentication solution.
+* [Clearance](https://github.com/thoughtbot/clearance) - Small and simple email & password based authenticaton for Rails.
+* [Devise](https://github.com/plataformatec/devise) - A flexible authentication solution for Rails based on Warden.
+* [JWT](https://github.com/jwt/ruby-jwt) - JSON Web Token implementation in Ruby.
+* [Knock](https://github.com/nsarno/knock) - Seamless JWT authentication for Rails API.
+* [OmniAuth](https://github.com/intridea/omniauth) - A library that standardizes multi-provider authentication utilizing Rack middleware.
+* [Shield](https://github.com/cyx/shield) - Authentication protocol for use in your routing and model context.
+* [Sorcery](https://github.com/NoamB/sorcery) - Magical Authentication for Rails 3 and 4.
+* [warden](https://github.com/hassox/warden) - General Rack Authentication Framework.
+* OAuth:
+  * [Doorkeeper](https://github.com/doorkeeper-gem/doorkeeper) - An OAuth2 provider for Rails.
+  * [OAuth2](https://github.com/intridea/oauth2) - A Ruby wrapper for the OAuth 2.0 protocol.
 
-  * [Devise](https://github.com/plataformatec/devise) - Devise is a flexible authentication solution for Rails based on Warden
-  * [Omniauth](https://github.com/intridea/omniauth) - OmniAuth is a flexible authentication system utilizing Rack middleware
-  * [Warden](https://github.com/hassox/warden) - General Rack Authentication Framework
-  * [AuthLogic](https://github.com/binarylogic/authlogic) - A simple ruby authentication solution
-  * [Sorcery](https://github.com/NoamB/sorcery) - Magical authentication for Rails 3 & 4
-  * [CanCanCan](https://github.com/CanCanCommunity/cancancan) Authorization gem for Rails (continued version of CanCan from ryanb)
-  * [pundit](https://github.com/elabs/pundit) - Minimal authorization using object oriented design.
-  * [authority](https://github.com/nathanl/authority) - ORM neutral authorization.
-  * [doorkeeper](https://github.com/doorkeeper-gem/doorkeeper) An OAuth 2 provider for Rails
+## Authorization
 
-## Build Tools
+* [acl9](https://github.com/be9/acl9) - Acl9 is a role-based authorization system that provides a concise DSL for securing your Rails application.
+* [Authority](https://github.com/nathanl/authority) - ORM-neutral way to authorize actions in your Rails app.
+* [CanCanCan](https://github.com/CanCanCommunity/cancancan) - Continuation of CanCan, an authorization Gem for Ruby on Rails.
+* [Declarative Authorization](https://github.com/stffn/declarative_authorization) - An authorization Rails plugin using a declarative DSL for specifying authorization rules in one place.
+* [Pundit](https://github.com/elabs/pundit) - Minimal authorization through OO design and pure Ruby classes.
 
-*Compile software from source code.*
+## Automation
 
-  * [teapot](https://github.com/ioquatix/teapot) A decentralised build tool for managing complex cross-platform projects
+* [Huginn](https://github.com/cantino/huginn) - Huginn is a system for building agents that perform automated tasks for you online.
 
 ## Caching
 
-*Libraries for caching data.*
+* [Action caching for Action Pack](https://github.com/rails/actionpack-action_caching) - Action caching for Action Pack.
+* [Dalli](https://github.com/mperham/dalli) - A high performance pure Ruby client for accessing memcached servers.
+* [Garner](https://github.com/artsy/garner) - A set of Rack middleware and cache helpers that implement various caching strategies.
+* [Kashmir](https://github.com/IFTTT/kashmir) - Kashmir is a Ruby DSL that makes serializing and caching objects a snap.
+* [Record Cache](https://github.com/orslumen/record-cache) - Cache Active Model Records in Rails 3.
+* [Second Level Cache](https://github.com/hooopo/second_level_cache) - Write-Through and Read-Through caching library for ActiveRecord 4.
 
-  * [rack-cache](https://github.com/rtomayko/rack-cache) HTTP Caching for Ruby Web Apps
-  * [Dalli](https://github.com/mperham/dalli) - a high performance pure Ruby client for accessing memcached servers.
+## CLI Builder
 
-## Cloud Services
+* [Cocaine](https://github.com/thoughtbot/cocaine) - A small library for doing (command) lines.
+* [Commander](https://github.com/commander-rb/commander) - The complete solution for Ruby command-line executables.
+* [formatador](https://github.com/geemus/formatador) - STDOUT text formatting.
+* [GLI](https://github.com/davetron5000/gli) - Git-Like Interface Command Line Parser.
+* [Main](https://github.com/ahoward/main) - A class factory and DSL for generating command line programs real quick.
+* [Rake](https://github.com/ruby/rake) - A make-like build utility for Ruby.
+* [Ru](https://github.com/tombenner/ru) - Ruby in your shell.
+* [Slop](https://github.com/leejarvis/slop) - Simple Lightweight Option Parsing.
+* [Thor](http://whatisthor.com) - A toolkit for building powerful command-line interfaces.
+* [Trollop](https://github.com/manageiq/trollop) - A commandline option parser for Ruby that just gets out of your way.
+* [TTY](https://github.com/peter-murach/tty) - Toolbox for developing CLI clients.
 
-  * [fog](https://github.com/fog/fog) The Ruby cloud services library
-  * [aws-sdk-ruby](https://github.com/aws/aws-sdk-ruby) The official AWS SDK for Ruby
+## CLI Utilities
+
+* [Pastel](https://github.com/peter-murach/pastel) - Terminal output styling with intuitive and clean API.
+* [Ruby/Progressbar](https://github.com/jfelchner/ruby-progressbar) - The most flexible text progress bar library for Ruby.
+
+## Cloud
+
+* [AWS SDK for Ruby](https://github.com/aws/aws-sdk-ruby) - The official AWS SDK for Ruby.
+* [Fog](https://github.com/fog/fog) - The Ruby cloud services library.
 
 ## CMS
+* [Alchemy CMS](http://alchemy-cms.com/about) - A powerful, userfriendly and flexible Open Source Rails CMS.
+* [Camaleon CMS](http://camaleon.tuzitio.com/) - A dynamic and advanced content management system based on Ruby on Rails 4.
+* [Comfortable Mexican Sofa](https://github.com/comfy/comfortable-mexican-sofa) - A powerful Rails 4 CMS Engine.
+* [LocomotiveCMS](http://www.locomotivecms.com) - A simple but powerful CMS based on Liquid templates and Mongodb database.
+* [Publify](https://github.com/publify/publify) - A self hosted Web publishing platform on Rails.
+* [Radiant](http://radiantcms.org) - A no-fluff, open source content management system designed for small teams.
+* [Refinery CMS](http://www.refinerycms.com) - An open source Ruby on Rails content management system for Rails 3 and 4.
+* [Storytime](https://github.com/CultivateLabs/storytime) - Rails 4+ CMS and bloging engine, with a core focus on content.
 
-*Content management systems*
+## Code Analysis and Metrics
 
-  * [Refinery](http://www.refinerycms.com) An extendable Ruby on Rails CMS that supports Rails 3.2 and 4
-  * [Comfortable Mexican Sofa](https://github.com/comfy/comfortable-mexican-sofa) A powerful Rails 4 CMS Engine
-  * [Browser](http://www.browsercms.org/) Humane Content Management for Rails
-  * [Locomotive](http://www.locomotivecms.com/) a brand new CMS system with super sexy UI and cool features
-  * [Radiant](http://radiantcms.org/) A no-fluff, open source content management system
-  * [Nesta](http://nestacms.com/) A lightweight CMS, implemented in Sinatra
-  * [alchemy_cms](https://github.com/AlchemyCMS/alchemy_cms) the most powerful, user friendly and flexible Rails CMS
-  * [weby](https://github.com/cercomp/weby) Newbie CMS in Ruby on Rails
+* [Barkeep](https://github.com/ooyala/barkeep) - Barkeep is a fast, fun way to review code. Engineering organizations can use it to keep the bar high.
+* [Brakeman](https://github.com/presidentbeef/brakeman) - A static analysis security vulnerability scanner for Ruby on Rails applications.
+* [Cane](https://github.com/square/cane) - Code quality threshold checking as part of your build.
+* [Coverband](https://github.com/danmayer/coverband) - Rack middleware to help measure production code coverage.
+* [Fasterer](https://github.com/DamirSvrtan/fasterer) - Make your Rubies go faster with this command line tool highly inspired by fast-ruby and Sferik's talk at Baruco Conf.
+* [Flay](https://github.com/seattlerb/flay) - Flay analyzes code for structural similarities. Differences in literal values, variable, class, method names, whitespace, programming style, braces vs do/end, etc are all ignored. Making this totally rad.
+* [Flog](https://github.com/seattlerb/flog) - Flog reports the most tortured code in an easy to read pain report. The higher the score, the more pain the code is in.
+* [fukuzatsu](https://gitlab.com/coraline/fukuzatsu/tree/master) - Complexity analysis tool with a rich web front-end.
+* [MetricFu](https://github.com/metricfu/metric_fu) - A fist full of code metrics.
+* [Pippi](https://github.com/tcopeland/pippi) - A utility for finding suboptimal Ruby class API usage, focused on runtime analysis.
+* [Pronto](https://github.com/mmozuras/pronto) - Quick automated code review of your changes.
+* [rails_best_practices](https://github.com/railsbp/rails_best_practices) - A code metric tool for rails projects.
+* [Reek](https://github.com/troessner/reek) - Code smell detector for Ruby.
+* [Rubocop](https://github.com/bbatsov/rubocop) - A static code analyzer, based on the community Ruby style guide.
+* [Rubycritic](https://github.com/whitesmith/rubycritic) - A Ruby code quality reporter.
+* [SimpleCov](https://github.com/colszowka/simplecov) - Code coverage for Ruby 1.9+ with a powerful configuration library and automatic merging of coverage across test suites.
+* [Traceroute](https://github.com/amatsuda/traceroute) - A Rake task gem that helps you find the dead routes and actions for your Rails 3+ app
 
-## Code Analysis and Linter
+## Coding Style Guides
 
-*Libraries and tools for analysing, parsing and manipulation codebases.*
+* [fast-ruby](https://github.com/JuanitoFatas/fast-ruby) - Writing Fast Ruby. Collect Common Ruby idioms.
+* [Rails style guide](https://github.com/bbatsov/rails-style-guide) - Community-driven Rails best practices and style for Rails 3 and 4.
+* [RSpec style guide](https://github.com/andreareginato/betterspecs) - Better Specs { rspec guidelines with ruby }.
+* [Ruby style guide](https://github.com/bbatsov/ruby-style-guide) - Community-driven Ruby coding style.
 
-  * [Rubocop](https://github.com/bbatsov/rubocop) - A Ruby static code analyzer, based on the community Ruby style guide.
-  * [ruby-lint](https://github.com/YorickPeterse/ruby-lint) - ruby-lint is a static code analysis tool for Ruby
-  * [brakeman](https://github.com/presidentbeef/brakeman) - Static analysis tool which checks Ruby on Rails applications for security vulnerabilities
+## Concurrency
 
-## Command-line Tools
-
-*Libraries for building command-line application.*
-
-  * [Commander](http://visionmedia.github.io/commander/) - The complete solution for Ruby command-line executables
-  * [Thor](https://github.com/erikhuda/thor) - Thor is a toolkit for building powerful command-line interfaces
+* [Celluloid](https://celluloid.io/) - Actor-based concurrent object framework for Ruby.
+* [Concurrent Ruby](https://github.com/ruby-concurrency/concurrent-ruby) - Modern concurrency tools including agents, futures, promises, thread pools, supervisors, and more. Inspired by Erlang, Clojure, Scala, Go, Java, JavaScript, and classic concurrency patterns.
+* [EventMachine](https://github.com/eventmachine/eventmachine) - An event-driven I/O and lightweight concurrency library for Ruby.
 
 ## Configuration
 
-*Libraries for storing configuration options.*
+* [Configatron](https://github.com/markbates/configatron) - Simple and feature rich configuration system for Ruby apps.
+* [Configus](https://github.com/kaize/configus) - Helps you easily manage environment specific settings.
+* [dotenv](https://github.com/bkeepers/dotenv) - Loads environment variables from `.env`.
+* [Econfig](https://github.com/elabs/econfig) - Flexible configuration for Rails applications.
+* [ENVied](https://github.com/eval/envied) - ensure presence and type of your app's ENV-variables
+* [Figaro](https://github.com/laserlemon/figaro) - Simple, Heroku-friendly Rails app configuration using `ENV` and a single YAML file.
+* [Global](https://github.com/railsware/global) - Provides accessor methods for your configuration data.
+* [RailsConfig](https://github.com/railsconfig/config) - Multi-environment yaml settings for Rails3.
 
-## CSS and Styling
+## Core Extensions
 
-  * [sass](https://github.com/sass/sass) A CSS preproccessor
-    * [sass-rails](https://github.com/rails/sass-rails) Rails stylesheet engine for Sass
-  * [less-rails](https://github.com/metaskills/less-rails) The dynamic stylesheet language for the Rails
-  * [compass](https://github.com/Compass/compass) A a Stylesheet Authoring Environment
-  * [bootstrap-sass](https://github.com/twbs/bootstrap-sass) Official Sass port of Bootstrap
-  * [foundation-rails](https://github.com/zurb/foundation-rails) Foundation for Rails
-  * [bootswatch-rails](https://github.com/maxim/bootswatch-rails) Bootswatches converted to SCSS ready to use in Rails
-  * [bourbon](https://github.com/thoughtbot/bourbon) A lightweight mixin library for Sass
+* [ActiveSupport](https://github.com/rails/rails/tree/master/activesupport) - A collection of utility classes and standard library extensions.
+* [Addressable](https://github.com/sporkmonger/addressable) - Addressable is a replacement for the URI implementation that is part of Ruby's standard library. It more closely conforms to RFC 3986, RFC 3987, and RFC 6570 (level 4), providing support for IRIs and URI templates.
+* [Finishing Moves](https://github.com/forgecrafted/finishing_moves) - Small, focused, incredibly useful methods added to core Ruby classes. Includes the endlessly useful `nil_chain`.
+* [Hamster](https://github.com/hamstergem/hamster) - Efficient, immutable, and thread-safe collection classes for Ruby.
+* [Ruby Facets](https://github.com/rubyworks/facets) - The premiere collection of general purpose method extensions and standard additions for Ruby.
+* Attributes
+  * [ActiveAttr](https://github.com/cgriego/active_attr) - What ActiveModel left out.
+  * [FastAttributes](https://github.com/applift/fast_attributes) - FastAttributes adds attributes with their types to the class.
+  * [Virtus](https://github.com/solnic/virtus) - Attributes on Steroids for Plain Old Ruby Objects.
+* Hash
+  * [Hashie](https://github.com/intridea/hashie) - A collection of tools that extend Hashes and make them more useful.
 
-## Data Validation
+## Country Data
 
-*Libraries for validating data. Used for forms in many cases.*
+* [Carmen](https://github.com/jim/carmen) - A repository of geographic regions.
+* [Countries](https://github.com/hexorx/countries) - All sorts of useful information about every country packaged as pretty little country objects.
+* [GlobalPhone](https://github.com/sstephenson/global_phone) - Parse, validate, and format phone numbers in Ruby using Google's libphonenumber database.
+* [i18n_data](https://github.com/grosser/i18n_data) - country/language names and 2-letter-code pairs, in 85 languages, for country/language i18n.
+* [normalize_country](https://github.com/sshaw/normalize_country) - Convert country names and codes to a standard, includes a conversion program for XMLs, CSVs and DBs.
 
-  * [kangal](https://github.com/lab2023/kangal) - Extended validation gem for email, subdomain, credit card, tax number etc
-  * [bin_checker](https://github.com/lab2023/bin_checker) - BIN validator for Turkish Banks
+## CRM
+
+* [Fat Free CRM](https://github.com/fatfreecrm/fat_free_crm) - An open source Ruby on Rails based customer relationship management platform.
+
+## Dashboards
+
+* [Dashing](http://shopify.github.io/dashing/) - A Sinatra based framework that lets you build beautiful dashboards.
+* [Dashing-Rails](https://github.com/gottfrois/dashing-rails) - The exceptionally handsome dashboard framework for Rails.
+
+## Data Processing and ETL
+
+* [Kiba](http://www.kiba-etl.org) - A lightweight data processing / ETL framework for Ruby.
 
 ## Data Visualization
 
-*Libraries for visualizing data.*
-
-  * [prosperity](https://github.com/smathieu/prosperity) The easiest way to graph data from your Rails models
+* [Chartkick](http://ankane.github.io/chartkick/) - Create beautiful Javascript charts with one line of Ruby. Works with Rails, Sinatra and most browsers (including IE 6).
+* [GeoPattern](https://github.com/jasonlong/geo_pattern) - Create beautiful generative geometric background images from a string.
+* [LazyHighCharts](https://github.com/michelson/lazy_high_charts) - A simple and extremely flexible way to use HighCharts from ruby code. Tested on Ruby on Rails, Sinatra and Nanoc, but it should work with others too.
+* [RailRoady](https://github.com/preston/railroady) - Ruby on Rails 3/4 model and controller UML class diagram generator.
+* [Rails Erd](https://github.com/voormedia/rails-erd) - Generate Entity-Relationship Diagrams for Rails applications.
+* [Ruby/GraphViz](https://github.com/glejeune/Ruby-Graphviz) - Ruby interface to the GraphViz graphing tool.
 
 ## Database Drivers
 
-*Libraties for connecting and operating databases.*
+* [Cassandra Driver](https://github.com/datastax/ruby-driver) - A pure ruby driver for Apache Cassandra with asynchronous io and configurable load balancing, reconnection and retry policies.
+* [DataObjects](https://github.com/datamapper/do) - An attempt to rewrite existing Ruby database drivers to conform to one, standard interface.
+* [mongo-ruby-driver](https://github.com/mongodb/mongo-ruby-driver) - MongoDB Ruby driver.
+* [moped](http://mongoid.org/en/moped/index.html) - A MongoDB driver for Ruby.
+* [mysql2](https://github.com/brianmario/mysql2) - A modern, simple and very fast Mysql library for Ruby (binding to libmysql).
+* [Neography](https://github.com/maxdemarzi/neography) - A thin Ruby wrapper to the Neo4j Rest API.
+* [Redic](https://github.com/amakawa/redic) - Lightweight Redis Client.
+* [redis-rb](https://github.com/redis/redis-rb) - A Ruby client that tries to match Redis' API one-to-one, while still providing an idiomatic interface.
+* [ruby-pg](https://bitbucket.org/ged/ruby-pg) - Ruby interface to PostgreSQL 8.3 and later.
+* [SQLite3](https://github.com/sparklemotion/sqlite3-ruby) - Ruby bindings for the SQLite3 embedded database.
+* [SQL Server](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter) - The SQL Server adapter for ActiveRecord.
 
-  * Relational Databases
-    * [ruby-pg](https://bitbucket.org/ged/ruby-pg/wiki/Home) Ruby interface to the PostgreSQL >= 8.4
-    * [mysql2](https://github.com/brianmario/mysql2) A modern, simple and very fast Mysql library for Ruby
-    * [sqlite3-ruby](https://github.com/sparklemotion/sqlite3-ruby) Ruby bindings for the SQLite3 embedded database
+## Database Tools
 
-  * NoSQL Databases
+* [Database Cleaner](https://github.com/DatabaseCleaner/database_cleaner) - Database Cleaner is a set of strategies for cleaning your database in Ruby.
+* [Foreigner](https://github.com/matthuhiggins/foreigner) - Adds foreign key helpers to migrations and correctly dumps foreign keys to schema.rb.
+* [Large Hadron Migrator](https://github.com/soundcloud/lhm) - Online MySQL schema migrations without locking the table.
+* [Lol DBA](https://github.com/plentz/lol_dba) - Scan your models and displays a list of columns that probably should be indexed.
+* [PgHero](https://github.com/ankane/pghero) - Postgres insights made easy.
+* [Rails DB](https://github.com/igorkasyanchuk/rails_db) - Database Viewer and SQL Query Runner.
+* [SchemaPlus](https://github.com/SchemaPlus/schema_plus) - SchemaPlus provides a collection of enhancements and extensions to ActiveRecord
+* [Seedbank](https://github.com/james2m/seedbank) - Seedbank allows you to structure your Rails seed data instead of having it all dumped into one large file.
+* [Seed dump](https://github.com/rroblak/seed_dump) - Rails 4 task to dump (parts) of your database to db/seeds.rb.
+* [Seed Fu](https://github.com/mbleigh/seed-fu) - Advanced seed data handling for Rails.
+* [Upsert](https://github.com/seamusabshere/upsert) - Upsert on MySQL, PostgreSQL, and SQLite3. Transparently creates functions (UDF) for MySQL and PostgreSQL; on SQLite3, uses INSERT OR IGNORE.
 
-## Date and Time
+## Date and Time Processing
 
-*Libraries for working with dates and times.*
-
-  * [stamp](https://github.com/jeremyw/stamp) Date and time formatting for humans
-
+* [biz](https://github.com/zendesk/biz) - Time calculations using business hours.
+* [business_time](https://github.com/bokmann/business_time) - Support for doing time math in business hours and days.
+* [ByStar](https://github.com/radar/by_star) - Find ActiveRecord objects by year, month, fortnight, week and more!
+* [Chronic](https://github.com/mojombo/chronic) - A natural language date/time parser written in pure Ruby.
+* [groupdate](https://github.com/ankane/groupdate) - The simplest way to group temporal data in ActiveRecord, arrays and hashes.
+* [ice_cube](https://github.com/seejohnrun/ice_cube) - A date recurrence library which allows easy creation of recurrence rules and fast querying.
+* [local_time](https://github.com/basecamp/local_time) - Rails Engine for cache-friendly, client-side local time.
+* [time-lord](https://github.com/krainboltgreene/time-lord) - Adds extra functionality to the time class.
+* [time_diff](https://github.com/abhidsm/time_diff) - Calculates the difference between two time.
+* [TZinfo](https://github.com/tzinfo/tzinfo) - Provides daylight savings aware transformations between times in different timezones.
+* [validates_timeliness](https://github.com/adzap/validates_timeliness) - Date and time validation plugin for ActiveModel and Rails.
+* [yymmdd](https://github.com/sshaw/yymmdd) - Tiny DSL for idiomatic date parsing and formatting.
 
 ## Debugging Tools
 
-*Libraries for debugging and developing.*
+* [Byebug](https://github.com/deivid-rodriguez/byebug) - A simple to use, feature rich debugger for Ruby 2.
+* [did_you_mean](https://github.com/yuki24/did_you_mean) - Adds class, method & attributute suggestions to error messages.
+* [Pry Byebug](https://github.com/deivid-rodriguez/pry-byebug) - Pry navigation commands via byebug.
+* [Rails Footnotes](https://github.com/josevalim/rails-footnotes) - Rails footnotes displays footnotes in your application for easy debugging, such as sessions, request parameters, cookies, filter chain, routes, queries, etc.
+* [Xray](https://github.com/brentd/xray-rails) - A development tool that reveals your UI's bones.
 
-  * [byebug](https://github.com/deivid-rodriguez/byebug) - Debugging in Ruby 2
-  * [debugger](https://github.com/cldwalker/debugger) - port of ruby-debug that works on 1.9.2 and 1.9.3
+## Decorators
+
+* [Draper](https://github.com/drapergem/draper) - Draper adds an object-oriented layer of presentation logic to your Rails application.
+* [ShowFor](https://github.com/plataformatec/show_for) - Quickly show a model information with I18n features. Like form_for for displaying model data.
 
 ## DevOps Tools
 
-*Software and libraries for DevOps.*
-
-  * [Puppet](https://github.com/puppetlabs/puppet) - Server automation framework and application
-  * [Chef](https://github.com/chef/chef) - A systems integration framework, built to bring the benefits of configuration management to your entire infrastructure.
-  * [Vagrant](https://www.vagrantup.com/) - Vagrant is a tool for building and distributing development environments.
-  * [Capistrano](http://capistranorb.com/) - Remote multi-server automation tool
-  * [Mina](https://github.com/mina-deploy/mina) Really fast deployer and server automation tool
-
-## Distribution
-
-*Libraries to create packaged executables for release distribution.*
-
-  * [fpm](https://github.com/jordansissel/fpm)  Building packages for multiple platforms (deb, rpm, etc) with great ease and sanity.
+* [Backup](https://github.com/backup/backup) - Provides an elegant DSL in Ruby for performing backups on UNIX-like systems.
+* [Blender](https://github.com/PagerDuty/blender) - A modular system orchestration framework with pluggable driver and host discovery.
+* [BOSH](https://github.com/cloudfoundry/bosh) - Cloud Foundry BOSH is an open source tool chain for release engineering, deployment and lifecycle management of large scale distributed services.
+* [Capistrano](http://capistranorb.com) - A remote server automation and deployment tool written in Ruby.
+* [Centurion](https://github.com/newrelic/centurion) - A mass deployment tool for Docker fleets.
+* [Chef](https://github.com/chef/chef) - A systems integration framework, built to bring the benefits of configuration management to your entire infrastructure.
+* [Deployinator](https://github.com/etsy/deployinator) - Deployinator is a deployment framework extracted from Etsy.
+* [Einhorn](https://github.com/stripe/einhorn) - Einhorn will open one or more shared sockets and run multiple copies of your process. You can seamlessly reload your code, dynamically reconfigure Einhorn, and more.
+* [Kochiku](https://github.com/square/kochiku) - Kochiku is a distributed platform for test automation.
+* [Lita](https://www.lita.io/) - ChatOps for Ruby: A pluggable chat bot framework usable with any chat service.
+* [Logstash](https://github.com/elastic/logstash) - Logs/event transport, processing, management, search.
+* [Mina](https://github.com/mina-deploy/mina) - Really fast deployer and server automation tool.
+* [Puppet](https://github.com/puppetlabs/puppet) - An automated administrative engine for your Linux, Unix, and Windows systems, performs administrative tasks (such as adding users, installing packages, and updating server configurations) based on a centralized specification.
+* [Request-log-analyzer](https://github.com/wvanbergen/request-log-analyzer) - Create reports based on your log files. Supports Rails, Apache, MySQL, Delayed::Job, and other formats.
+* [Rubber](https://github.com/rubber/rubber) - The rubber plugin enables relatively complex multi-instance deployments of RubyOnRails applications to Amazon's Elastic Compute Cloud (EC2).
+* [SSHKey](https://github.com/bensie/sshkey) - SSH private and public key generator in pure Ruby (RSA & DSA).
+* [Ruby-LXC](https://github.com/lxc/ruby-lxc) - Native ruby binding for Linux containers.
+* [Vagrant](https://www.vagrantup.com/) - Create and configure lightweight, reproducible, and portable development environments.
 
 ## Documentation
 
-*Libraries for generating project documentation.*
+* [Annotate](https://github.com/ctran/annotate_models) - Add a comment documenting the current schema to the top or bottom of each of your ActiveRecord models.
+* [Apipie](https://github.com/Apipie/apipie-rails) - Rails API documentation and display tool using Ruby syntax.
+* [Asciidoctor](http://asciidoctor.org) - A fast, Ruby-based text processor & publishing toolchain for converting AsciiDoc to HTML5, DocBook, EPUB3, PDF & more.
+* [Documentation](https://github.com/adamcooke/documentation) - A Rails engine to provider the ability to add documentation to a Rails application.
+* [GitHub Changelog Generator](https://github.com/skywinder/github-changelog-generator) - Automatically generate change log from your tags, issues, labels and pull requests on GitHub.
+* [grape-swagger](https://github.com/ruby-grape/grape-swagger) - Add swagger compliant documentation to your Grape API.
+* [Hologram](https://github.com/trulia/hologram) - A markdown based documentation system for style guides. It parses comments in your CSS and helps you turn them into a beautiful style guide.
+* [Inch](https://github.com/rrrene/inch) - Inch is a documentation measurement and evalutation tool for Ruby code, based on YARD.
+* [RDoc](https://github.com/rdoc/rdoc) - RDoc produces HTML and command-line documentation for Ruby projects.
+* [rspec_api_documentation](https://github.com/zipmark/rspec_api_documentation) - Automatically generate API documentation from RSpec.
+* [YARD](http://yardoc.org) - YARD enables the user to generate consistent, usable documentation that can be exported to a number of formats very easily.
 
-  * [rdoc](https://github.com/rdoc/rdoc) HTML and online documentation for Ruby projects
-  * [yard](https://github.com/lsegal/yard) A Ruby Documentation tool
+## E-Commerce and Payments
 
-## Downloader
+* [Active Merchant](https://github.com/activemerchant/active_merchant) - A simple payment abstraction library extracted from Shopify.
+* [credit_card_validations](https://github.com/Fivell/credit_card_validations) - A ruby gem for validating credit card numbers, generating valid numbers, Luhn checks.
+* [Koudoku](https://github.com/andrewculver/koudoku) - Robust subscription support for Ruby on Rails apps using Stripe, including out-of-the-box pricing pages, payment pages, and subscription management.
+* [Payola](https://github.com/peterkeen/payola) - Drop-in Rails engine for accepting payments with Stripe.
+* [Paypal Merchant SDK](https://github.com/paypal/merchant-sdk-ruby) - Official Paypal Merchant SDK for Ruby.
+* [Piggybak](https://github.com/piggybak/piggybak) - Modular, Extensible open-source ecommerce solution for Ruby on Rails.
+* [ROR Ecommerce](https://github.com/drhenner/ror_ecommerce) - A Rails e-commerce platform.
+* [Shoppe](http://tryshoppe.com) - A Rails-based e-commerce platform which allows you to easily introduce a catalogue-based store into your Rails 4 applications.
+* [Solidus](https://github.com/solidusio/solidus) - An open source, eCommerce application for high volume retailers.
+* [Spree](https://github.com/spree/spree) - Spree is a complete open source e-commerce solution for Ruby on Rails.
+* [stripe-ruby](https://github.com/stripe/stripe-ruby) - Stripe Ruby bindings.
 
-*Libraries for downloading.*
+## Ebook
 
-## E-Commerce & Online Paying
+* [Bookshop](https://github.com/worlduniting/bookshop) - Bookshop is a an open-source agile book development and publishing framework for authors, editors.
+* [Eeepub](https://github.com/jugyo/eeepub) - EeePub is a Ruby ePub generator.
+* [Gepub](https://github.com/skoji/gepub) - A generic EPUB library for Ruby : supports EPUB 3.
+* [Git Scribe](https://github.com/schacon/git-scribe) - Basically the best way to write an ebook.
+* [Mobi](https://github.com/jkongie/mobi) - A Ruby way to read MOBI format metadata.
+* [Review](https://github.com/kmuto/review) - Re:VIEW is flexible document format/conversion system.
 
-  * [Active Merchant](https://github.com/activemerchant/active_merchant) - A simple payment abstraction library extracted from Shopify.
-  * [Spree](https://github.com/spree/spree) - A complete open source e-commerce solution for Ruby on Rails.
-  * [PayPal Merchant SDK](https://github.com/paypal/merchant-sdk-ruby) - Provides Ruby APIs for processing payments, recurring payments, subscriptions and transactions using PayPal's Merchant APIs.
+## Email
 
-## E-Mail
+* [Griddler](https://github.com/thoughtbot/griddler) - Simplify receiving email in Rails
+* [Incoming](https://github.com/honeybadger-io/incoming) - Incoming! helps you receive email in your Rack apps.
+* [LetterOpener](https://github.com/ryanb/letter_opener) - Preview mail in the browser instead of sending.
+* [Mail](https://github.com/mikel/mail) - A Really Ruby Mail Library.
+* [MailCatcher](http://mailcatcher.me) - Catches mail and serves it through a dream.
+* [MailForm](https://github.com/plataformatec/mail_form) - Send e-mail straight from forms in Rails with I18n, validations, attachments and request information.
+* [Mailman](https://github.com/mailman/mailman) - An incoming mail processing microframework in Ruby.
+* [Markerb](https://github.com/plataformatec/markerb) - Allows you to render multipart e-mails from a single template written in Markdown.
+* [Pony](https://github.com/benprew/pony) - The express way to send mail from Ruby.
+* [premailer-rails](https://github.com/fphilipe/premailer-rails) - CSS styled emails without the hassle.
+* [Roadie](https://github.com/Mange/roadie) - Roadie tries to make sending HTML emails a little less painful by inlining stylesheets and rewriting relative URLs for you inside your emails.
+* [Sup](https://github.com/sup-heliotrope/sup) - A curses threads-with-tags style email client.
 
-*Libraries for sending and parsing email.*
+## Encryption
 
-  * [mail](https://github.com/mikel/mail) A Really Ruby Mail Library
-  * [mailman](https://github.com/mailman/mailman) An incoming mail processing microframework in Ruby
+* [Symmetric Encryption](http://reidmorrison.github.io/symmetric-encryption/) - Transparently encrypt ActiveRecord, Mongoid, and MongoMapper attributes. Encrypt passwords in configuration files. Encrypt entire files at rest.
 
 ## Environment Management
 
-*Libraries for Ruby version and environment management.*
-
-  * [chruby](https://github.com/postmodern/chruby) - Changes the current Ruby
-  * [chgems](https://github.com/postmodern/chgems) - Chroot for RubyGems
-  * [rvm](https://rvm.io/) - Ruby Version Manager
-  * [rbenv](http://rbenv.org/) - Groom your app’s Ruby environment
-  * [ruby-install](https://github.com/postmodern/ruby-install) - Installs Ruby, JRuby, Rubinius, MagLev or MRuby
-  * [ruby-build](https://github.com/sstephenson/ruby-build) - Compile and install Ruby
+* [chgems](https://github.com/postmodern/chgems) - Chroot for RubyGems.
+* [chruby](https://github.com/postmodern/chruby) - Change your current Ruby. No shims, no crazy options or features, ~90 LOC.
+* [fry](https://github.com/terlar/fry) - Simple ruby version manager for fish.
+* [gem_home](https://github.com/postmodern/gem_home) - A tool for changing your $GEM_HOME.
+* [rbenv](https://github.com/sstephenson/rbenv) - Use rbenv to pick a Ruby version for your application and guarantee that your development environment matches production.
+* [ruby-build](https://github.com/sstephenson/ruby-build) - Compile and install Ruby.
+* [ruby-install](https://github.com/postmodern/ruby-install) - Installs Ruby, JRuby, Rubinius, MagLev or MRuby.
+* [RVM](https://rvm.io) - RVM is a command-line tool which allows you to easily install, manage, and work with multiple ruby environments from interpreters to sets of gems.
+* [Tokaido](https://github.com/tokaido/tokaidoapp/releases) - Ruby, Rails, SQLite and Redis encapsulated in a single drag-and-drop OS X app, designed to make installing a working RoR environment easy for beginners.
 
 ## Error Handling
 
-*Libraries for exception and error handling.*
+* [Airbrake](https://github.com/airbrake/airbrake) - The official Airbrake library for Ruby on Rails (and other Rack based frameworks).
+* [Better Errors](https://github.com/charliesome/better_errors) - Better error page for Rack apps.
+* [Errbit](http://errbit.github.io/errbit) - The open source, self-hosted error catcher.
+* [Exception Handler](https://github.com/richpeck/exception_handler) - Custom error pages.
+* [Exception Notification](https://github.com/smartinez87/exception_notification) - A set of notifiers for sending notifications when errors occur in a Rack/Rails application.
+* [Honeybadger](https://www.honeybadger.io/) - Exception, uptime, and performance monitoring for Ruby.
+* [Nesty](https://github.com/skorks/nesty) - Nested exceptions for Ruby.
+* [Raven Ruby](https://github.com/getsentry/raven-ruby) - Raven is a Ruby client for Sentry.
 
-  * [Exception Notification](https://github.com/smartinez87/exception_notification) - A set of notifiers for sending notifications when errors occur in a Rack/Rails application
-  * [Errbit](http://errbit.github.io/errbit) - The open source, self-hosted error catcher
-  * [Airbrake](https://github.com/airbrake/airbrake) - The official Airbrake library for Ruby on Rails (and other Rack based frameworks)
-  * [Better Errors](https://github.com/charliesome/better_errors) - Better error page for Rack apps
+## File Upload
 
-## File Uploading
+* [CarrierWave](https://github.com/carrierwaveuploader/carrierwave) - Classier solution for file uploads for Rails, Sinatra and other Ruby web frameworks.
+* [DragonFly](https://github.com/markevans/dragonfly) - A Ruby gem for on-the-fly processing - suitable for image uploading in Rails, Sinatra and much more!.
+* [PaperClip](https://github.com/thoughtbot/paperclip) - Easy file attachment management for ActiveRecord.
+* [rack-secure-upload](https://github.com/dtaniwaki/rack-secure-upload) - Upload files securely.
+* [Refile](https://github.com/refile/refile) - A modern file upload library for Ruby applications, Refile is an attempt by CarrierWave's original author to fix the design mistakes and overengineering in CarrierWave.
 
-*Libraries for handling file uploads.*
+## Form Builder
 
-  * [paperclip](https://github.com/thoughtbot/paperclip) Easy file attachment management for ActiveRecord
-  * [dragonfly](https://github.com/markevans/dragonfly) On-the-fly processing - suitable for image uploading in Rails, Sinatra and much more
-  * [carrierwave](https://github.com/carrierwaveuploader/carrierwave) Classier solution for file uploads for Rails, Sinatra and other Ruby web frameworks
-
-## Feature flipping
-
-*Libaries for flipping features*
-
-  * [helioth] (https://github.com/gmontard/helioth) Manage feature flipping and rollout
-  * [flipper] (https://github.com/jnunemaker/flipper) feature flipping for ANYTHING
-  * [flip] (https://github.com/pda/flip) Flip lets you declare and manage feature flags, backed by cookies (private testing) and database (site-wide)
-  * [rollout] (https://github.com/FetLife/rollout) Feature flippers.
-
-## Foreign Function Interface
-
-*Libraries for providing foreign function interface.*
-
-## Forms
-
-*Libraries for working with forms.*
-
-  * [simple_form](https://github.com/plataformatec/simple_form) Forms made easy for Rails
-  * [formtastic](https://github.com/justinfrench/formtastic) A Rails form builder plugin with semantically rich and accessible markup
+* [Abracadabra](https://github.com/TrevorHinesley/abracadabra) - The gem that swaps out text with a fully-compliant Rails form in one click.
+* [Formtastic](https://github.com/justinfrench/formtastic) - A Rails form builder plugin with semantically rich and accessible markup.
+* [Rails Bootstrap Forms](https://github.com/bootstrap-ruby/rails-bootstrap-forms) - Rails form builder that makes it super easy to create beautiful-looking forms with Twitter Bootstrap 3+.
+* [Simple Form](https://github.com/plataformatec/simple_form) - Rails forms made easy.
+* Nested Forms:
+  * [ActiveForm](https://github.com/railsgsoc/actionform) - Provides an object-oriented approach to represent your forms by building a Form Object which deals with create/update actions of nested objects in a more seamless way.
+  * [Cocoon](https://github.com/nathanvda/cocoon) - Dynamic nested forms using jQuery made easy; works with formtastic, simple_form or default forms.
+  * [Reform](https://github.com/apotonick/reform) - Gives you a form object with validations and nested setup of models. It is completely framework-agnostic and doesn't care about your database.
 
 ## Game Development
 
-*Awesome game development libraries.*
-
-  * [Gosu](https://www.libgosu.org/) - A 2D game development library for the Ruby and C++ programming languages
-
+* [Gosu](https://www.libgosu.org/) - A 2D game development library for the Ruby and C++ programming languages.
+* [Yeah](https://github.com/yeahrb/yeah) - Practical Ruby video game framework.
 
 ## Geolocation
 
-*Libraries for geocoding addresses and working with latitudes and longitudes.*
-
-  * [geocoder](https://github.com/alexreisner/geocoder) Complete Ruby geocoding solution
-  * [Geokit](https://github.com/geokit/geokit) - Geokit gem provides geocoding and distance/heading calculations.
+* [Geocoder](https://github.com/alexreisner/geocoder) - A complete geocoding solution for Ruby. With Rails it adds geocoding (by street or IP address), reverse geocoding (find street address based on given coordinates), and distance queries.
+* [geoip](https://github.com/cjheath/geoip) - Searches a GeoIP database for a given host or IP address, and returns information about the country where the IP address is allocated, and the city, ISP and other information.
+* [Geokit](https://github.com/geokit/geokit) - Geokit gem provides geocoding and distance/heading calculations.
+* [Google Maps for Rails](https://github.com/apneadiving/Google-Maps-for-Rails) - Enables easy Google map + overlays creation in Ruby apps.
 
 ## Git Tools
 
-*Libraries for working with Git VCS*
-
-  * [katip](https://github.com/lab2023/katip) - Change logger for Git initialized projects
+* [ginatra](https://github.com/NARKOZ/ginatra) - A web frontend for Git repositories.
+* [git-auto-bisect](https://github.com/grosser/git-autobisect) - Find the commit that broke master.
+* [git-spelunk](https://github.com/osheroff/git-spelunk) - Dig through git blame history.
+* [git-up](https://github.com/aanand/git-up) - Fetch and rebase all locally-tracked remote branches.
+* [git-whence](https://github.com/grosser/git-whence) - Find which merge a commit came from.
+* [Overcommit](https://github.com/brigade/overcommit) - A fully configurable and extendable Git hook manager.
+* [Rugged](https://github.com/libgit2/rugged) - Ruby bindings to libgit2.
 
 ## GUI
 
-*Libraries for working with graphical user interface applications.*
+* [qtbindings](https://github.com/ryanmelt/qtbindings) - Allows the QT Gui toolkit to be used from Ruby.
+* [RubyGnome2](http://ruby-gnome2.osdn.jp/) - Ruby language bindings for the GNOME 2.0 development environment.
+* [Shoes](http://shoesrb.com) - Shoes makes building little graphical programs for Mac, Windows, and Linux super simple.
 
-  * [shoes](https://github.com/shoes/shoes) A tiny graphical app kit for ruby
-    * [shoes4](https://github.com/shoes/shoes4) the next version of Shoes
+## HTML/XML Parsing
 
-## High Performance
-
-*Libraries for making Ruby faster.*
-
-  * [EventMachine](https://github.com/eventmachine/eventmachine) - EventMachine: fast, simple event-processing library for Ruby programs
-  * [Celluloid](https://celluloid.io/) - Actor-based concurrent object framework for Ruby
-
-## HTML/XML/CSS Manipulation
-
-*Libraries for working with HTML, XML & CSS.*
-
-  * [Nokogiri](http://www.nokogiri.org/)
-  * [loofah](https://github.com/flavorjones/loofah) A general library for manipulating and transforming HTML/XML documents and fragments
+* [HappyMapper](https://github.com/dam5s/happymapper) - Object to XML mapping library, using Nokogiri.
+* [HTML::Pipeline](https://github.com/jch/html-pipeline) - HTML processing filters and utilities.
+* [Nokogiri](http://www.nokogiri.org/) - An HTML, XML, SAX, and Reader parser with XPath and CSS selector support.
+* [Oga](https://github.com/YorickPeterse/oga) - An XML/HTML parser written in Ruby. Oga does not require system libraries such as libxml, making it easier and faster to install on various platforms.
+* [Ox](https://github.com/ohler55/ox) - A fast XML parser and Object marshaller.
+* [ROXML](https://github.com/Empact/roxml) - Custom mapping and bidirectional marshalling between Ruby and XML using annotation-style class methods, via Nokogiri or LibXML.
 
 ## HTTP
 
-*Libraries for working with HTTP.*
+* [excon](https://github.com/excon/excon) - Usable, fast, simple Ruby HTTP 1.1. It works great as a general HTTP(s) client and is particularly well suited to usage in API clients.
+* [Faraday](https://github.com/lostisland/faraday) - an HTTP client lib that provides a common interface over many adapters (such as Net::HTTP) and embraces the concept of Rack middleware when processing the request/response cycle.
+* [Http Client](https://github.com/nahi/httpclient) - Gives something like the functionality of libwww-perl (LWP) in Ruby.
+* [HTTP](https://github.com/httprb/http) - The HTTP Gem: a simple Ruby DSL for making HTTP requests.
+* [httparty](https://github.com/jnunemaker/httparty) - Makes http fun again!
+* [Http-2](https://github.com/igrigorik/http-2) - Pure Ruby implementation of HTTP/2 protocol
+* [Patron](https://github.com/toland/patron) - Patron is a Ruby HTTP client library based on libcurl.
+* [RESTClient](https://github.com/rest-client/rest-client) - Simple HTTP and REST client for Ruby, inspired by microframework syntax for specifying actions.
+* [Savon](https://github.com/savonrb/savon) - Savon is a SOAP client for the Ruby programming language.
+* [Sawyer](https://github.com/lostisland/sawyer) - Secret user agent of HTTP, built on top of Faraday.
+* [Spyke](https://github.com/balvig/spyke) - Interact with REST services in an ActiveRecord-like manner.
+* [Typhoeus](https://github.com/typhoeus/typhoeus) - Typhoeus wraps libcurl in order to make fast and reliable requests.
 
-  * [httparty](https://github.com/jnunemaker/httparty) Makes http fun again!
-  * [faraday](https://github.com/lostisland/faraday) Simple, but flexible HTTP client library, with support for multiple backends.
-  * [http](https://github.com/httprb/http) A simple Ruby DSL for making HTTP requests
-  * [excon](https://github.com/excon/excon) Usable, fast, simple HTTP(S) 1.1 for Ruby
-  * [nestful](https://github.com/maccman/nestful) Simple Ruby HTTP/REST client with a sane API
+## Image Processing
 
-## Imagery
+* [MiniMagick](https://github.com/minimagick/minimagick) - A ruby wrapper for ImageMagick or GraphicsMagick command line.
+* [Phasion](https://github.com/westonplatter/phashion) - Ruby wrapper around pHash, the perceptual hash library for detecting duplicate multimedia files.
+* [PSD.rb](https://github.com/layervault/psd.rb) - Parse Photoshop files in Ruby with ease.
+* [RMagick](https://github.com/rmagick/rmagick) - RMagick is an interface between Ruby and ImageMagick.
+* [Skeptick](https://github.com/maxim/skeptick) - Skeptick is an all-purpose DSL for building and running ImageMagick commands.
 
-*Libraries for manipulating images.*
+## Implementations/Compilers
 
-  * [rmagick](https://github.com/rmagick/rmagick) An interface to the ImageMagick and GraphicsMagick image processing libraries
-    *  [minimagick](https://github.com/minimagick/minimagick) Minified version of rmagick
-  * [chunky_png](https://github.com/wvanbergen/chunky_png) Read/write access to PNG images in pure Ruby
-  * [image_optim](https://github.com/toy/image_optim) Optimize images using multiple utilities
-  * [magickly](https://github.com/afeld/magickly) image manipulation as a (plugin-able) service
+* [JRuby](https://github.com/jruby/jruby) - A Java implementation of the Ruby language.
+* [MRuby](https://github.com/mruby/mruby) - Lightweight Ruby. Can be linked and embedded in your application.
+* [Opal](https://github.com/opal/opal) - Ruby to Javascript compiler.
+* [Rubinius](https://github.com/rubinius/rubinius) - An implementation of the Ruby programming language. Rubinius includes a bytecode virtual machine, Ruby syntax parser, bytecode compiler, generational garbage collector, just-in-time (JIT) native machine code compiler, and Ruby Core and Standard libraries.
 
 ## Internationalization
 
-*Libraries for woking with i18n.*
+* [FastGettext](https://github.com/grosser/fast_gettext) - Ruby internationalization tool with less memory, simple, clean namespace and threadsafe.
+* [Globalize](https://github.com/globalize/globalize) - Globalize builds on the I18n API in Ruby on Rails to add model translations to ActiveRecord models.
+* [i18n-tasks](https://github.com/glebm/i18n-tasks) - Manage missing and unused translations with the awesome power of static analysis.
+* [i18n](https://github.com/svenfuchs/i18n) - Ruby Internationalization and localization solution.
+* [r18n](https://github.com/ai/r18n) - Advanced i18n library for Rails, Sinatra, desktop apps, models, works well with complex languages like Russian.
+* [Termit](https://github.com/pawurb/termit) - Google Translate with speech synthesis in your terminal.
+* [twitter-cldr-rb](https://github.com/twitter/twitter-cldr-rb) - Ruby implementation of the ICU (International Components for Unicode) that uses the Common Locale Data Repository to format dates, plurals, and more.
 
-  * [i18n](https://github.com/svenfuchs/i18n) - Basic internationalization(i18n) library for Ruby
-  * [globalize](https://github.com/globalize/globalize) Rails I18n de-facto standard library for ActiveRecord model/data translation
-  * [i18n-tasks](https://github.com/glebm/i18n-tasks) Manage translations in ruby applications with the awesome power of static analysis
+## IRB
+
+* [Hirb](https://github.com/cldwalker/hirb) - A mini view framework for console/irb that's easy to use, even while under its influence. Console goodies include a no-wrap table, auto-pager, tree and menu.
+* [irbtools](https://github.com/janlelis/irbtools) - Improvements for Ruby's IRB.
+* [Pry](https://github.com/pry/pry) - A powerful alternative to the standard IRB shell for Ruby.
 
 ## Logging
 
-*Libraries for generating and working with log files.*
-
-  * [Logstash](https://github.com/elastic/logstash) Logstash is a tool for managing events and logs.
+* [Cabin](https://github.com/jordansissel/ruby-cabin) - Structured+contextual logging experiments in Ruby.
+* [Fluentd](https://github.com/fluent/fluentd) - Fluentd collects events from various data sources and writes them to files, database or other types of storages.
+* [HttpLog](https://github.com/trusche/httplog) - Log outgoing HTTP requests.
+* [Log4r](https://github.com/colbygk/log4r) - Log4r is a comprehensive and flexible logging library for use in Ruby programs.
+* [Logging](https://github.com/TwP/logging) - A flexible logging library for use in Ruby programs based on the design of Java's log4j library.
+* [Lograge](https://github.com/roidrage/lograge) - An attempt to tame Rails' default policy to log everything.
+* [MongoDB Logger](https://github.com/le0pard/mongodb_logger) - MongoDB logger for Rails.
+* [Scrolls](https://github.com/asenchi/scrolls) - Simple logging.
+* [Semantic Logger](https://github.com/rocketjob/semantic_logger) - Scalable, next generation logging for Ruby.
+* [Yell](https://github.com/rudionrails/yell) - Your Extensible Logging Library.
 
 ## Machine Learning
 
-*Libraries for Machine Learning.*
+* [PredictionIO Ruby SDK](https://github.com/PredictionIO/PredictionIO-Ruby-SDK) - The PredictionIO Ruby SDK provides a convenient API to quickly record your users' behavior and retrieve personalized predictions for them.
+* [rb-libsvm](https://github.com/febeling/rb-libsvm) - Ruby language bindings for LIBSVM. SVM is a machine learning and classification algorithm.
+* [ruby-band](https://github.com/arrigonialberto86/ruby-band) - Machine learning and data mining algorithms for JRuby.
+* [Ruby Datumbox Wrapper](https://github.com/marloncarvalho/ruby-datumbox) - It's a simple Ruby Datumbox Wrapper. At the moment the API currently allows you to build applications that make use of machine learning algorithms.
 
-  * [PredictionIO Ruby SDK](https://github.com/PredictionIO/PredictionIO-Ruby-SDK) - The PredictionIO Ruby SDK provides a convenient API to quickly record your users' behavior and retrieve personalized predictions for them
+## Markdown Processors
 
-## MapReduce
+* [kramdown](https://github.com/gettalong/kramdown) - Kramdown is yet-another-markdown-parser but fast, pure Ruby, using a strict syntax definition and supporting several common extensions.
+* [Maruku](https://github.com/bhollis/maruku) - A pure-Ruby Markdown-superset interpreter.
+* [Redcarpet](https://github.com/vmg/redcarpet) - A fast, safe and extensible Markdown to (X)HTML parser.
 
-*Framworks and libraries for MapReduce.*
+## Misc
+
+* [auto_html](https://github.com/dejan/auto_html) - Rails extension for transforming URLs to appropriate resource (image, link, YouTube, Vimeo video...)
+* [Betty](https://github.com/pickhardt/betty) - Friendly English-like interface for your command line. Don't remember a command? Ask Betty.
+* [Device Detector](https://github.com/podigee/device_detector) - A precise and fast user agent parser and device detector, backed by the largest and most up-to-date user agent database.
+* [Diffy](https://github.com/samg/diffy) - Easy Diffing With Ruby.
+* [Foreman](https://github.com/ddollar/foreman) - Manage Procfile-based applications.
+* [Gollum](https://github.com/gollum/gollum) - A simple, Git-powered wiki with a sweet API and local frontend.
+* [gon](https://github.com/gazay/gon) - If you need to send some data to your js files and you don't want to do this with long way through views and parsing - use gon.
+* [Guard](https://github.com/guard/guard) - A command line tool to easily handle events on file system modifications.
+* [JsonCompare](https://github.com/a2design-inc/json-compare) - Returns the difference between two JSON files.
+* [play ►](https://github.com/play/play) - Your company's dj.
+* [pygments.rb](https://github.com/tmm1/pygments.rb) - A Ruby wrapper for the Python pygments syntax highlighter.
+* [QR-code](https://github.com/whomwah/rqrcode) - A Ruby library that encodes QR Codes
+* [RubyDNS](https://github.com/ioquatix/rubydns) - A high-performance DNS server which can be easily integrated into other projects or used as a stand-alone daemon.
+* [Ruby Operators](http://ruby-operators.herokuapp.com/) - A webpage showing awesome names for different Ruby operators.
+
+## Mobile Development
+
+* [dryrun](https://github.com/cesarferreira/dryrun) - Try any Android library on your smartphone directly from the command line.
+* [fastlane](https://github.com/fastlane/fastlane) - Connect all iOS deployment tools into one streamlined workflow.
+* [Ruboto](http://ruboto.org) - A platform for developing full stand-alone apps for Android using the Ruby language and libraries.
+* [RubyMotion](http://www.rubymotion.com) - A revolutionary toolchain that lets you quickly develop and test full-fledged native iOS and OS X applications for iPhone, iPad, Mac and Android.
+* [Ruby Push Notifications](https://github.com/calonso/ruby-push-notifications) - iOS, Android and Windows Phone Push notifications made easy.
+
+## Money
+
+* [eu_central_bank](https://github.com/RubyMoney/eu_central_bank) - A gem that calculates the exchange rate using published rates from European Central Bank.
+* [Monetize](https://github.com/RubyMoney/monetize) - A library for converting various objects into Money objects.
+* [Money](https://github.com/RubyMoney/money) - A Ruby Library for dealing with money and currency conversion.
+
+## Music and Sound
+
+* [Sonic Pi](https://github.com/samaaron/sonic-pi) - A live coding synth for everyone originally designed to support computing and music lessons.
 
 ## Natural Language Processing
 
-*Libraries for working with human languages.*
+* [Parslet](http://kschiess.github.io/parslet/) - A small Ruby library for constructing parsers in the PEG (Parsing Expression Grammar) fashion.
+* [pocketsphinx-ruby](https://github.com/watsonbox/pocketsphinx-ruby) - Ruby speech recognition with Pocketsphinx.
+* [Pragmatic Segmenter](https://github.com/diasks2/pragmatic_segmenter) - Pragmatic Segmenter is a rule-based sentence boundary detection gem that works out-of-the-box across many languages.
+* [Text](https://github.com/threedaymonk/text) - A collection of text algorithms including Levenshtein distance, Metaphone, Soundex 2, Porter stemming & White similarity.
+* [Treat](https://github.com/louismullie/treat) - Treat is a toolkit for natural language processing and computational linguistics in Ruby.
+* [Treetop](https://github.com/cjheath/treetop) - PEG (Parsing Expression Grammar) parser.
+* [Words Counted](https://github.com/abitdodgy/words_counted) - A highly customisable Ruby text analyser and word counter.
 
-* [Treat](https://github.com/louismullie/treat) - Treat is a toolkit for natural language processing and computational linguistics in Ruby
+## Navigation
 
-## Networking
+* [active_link_to](https://github.com/comfy/active_link_to) - View helper to manage "active" state of a link.
+* [Breadcrumbs on Rails](https://github.com/weppos/breadcrumbs_on_rails) - A simple Ruby on Rails plugin for creating and managing a breadcrumb navigation for a Rails project.
+* [Gretel](https://github.com/lassebunk/gretel) - A Ruby on Rails plugin that makes it easy yet flexible to create breadcrumbs.
+* [loaf](https://github.com/peter-murach/loaf) - Manages and displays breadcrumb trails in Rails app - lean & mean.
+* [Simple Navigation](https://github.com/codeplant/simple-navigation) - A ruby gem for creating navigation (html list, link list or breadcrumbs with multiple levels) for your Rails 2, 3 & 4, Sinatra or Padrino.
 
-*Libraries for network programming.*
+## ORM/ODM
 
-## ORM
+* [ActiveRecord](https://github.com/rails/rails/tree/master/activerecord) - Object-relational mapping in Rails.
+* [DataMapper](https://github.com/datamapper/dm-core) - ORM which works well with legacy databases. Last release (1.2.0) was on 13 October 2011.
+* [Guacamole](https://github.com/triAGENS/guacamole) -  An ODM for ArangoDB.
+* [Mongoid](https://github.com/mongoid/mongoid) - An ODM (Object-Document-Mapper) framework for MongoDB in Ruby.
+* [MongoMapper](https://github.com/mongomapper/mongomapper) - A Ruby Object Mapper for Mongo.
+* [MongoModel](https://github.com/spohlenz/mongomodel) -  Ruby ODM for interfacing with MongoDB databases.
+* [Neo4j.rb](http://neo4jrb.io) - A Neo4j OGM (Object-Graph-Mapper) for use in Ruby on Rails and Rack frameworks heavily inspired by ActiveRecord.
+* [NoBrainer](https://github.com/nviennot/nobrainer/) - A RethinkDB ORM for Ruby
+* [Ohm](https://github.com/soveran/ohm) - Object-hash mapping library for Redis.
+* [Perpetuity](https://github.com/jgaskins/perpetuity) - Persistence gem for Ruby objects using the Data Mapper pattern.
+* [ROM](https://github.com/rom-rb/rom) - Ruby Object Mapper (ROM) is an experimental Ruby library with the goal to provide powerful object mapping capabilities without limiting the full power of your datastore.
+* [Sequel](https://github.com/jeremyevans/sequel) - Sequel is a simple, flexible, and powerful SQL database access toolkit for Ruby.
 
-*Libraries that implement Object-Relational Mapping or datamapping techniques.*
+## ORM/ODM Extensions
 
-* Relational Databases
-
-  * [ActiveRecord](https://www.ruby-toolbox.com/projects/activerecord) - Databases on Rails. Build a persistent domain model by mapping database tables to Ruby classes
-  * [DataMapper](http://datamapper.org/) - DataMapper is an Object Relational Mapper written in Ruby. The goal is to create an ORM which is fast, thread-safe and feature rich.
-  * [Sequel](http://sequel.jeremyevans.net/) - The Database Toolkit for Ruby
-
-* NoSQL Databases
-
-  * [Mongoid](http://mongoid.org) - Mongoid (pronounced mann-goyd) is an Object-Document-Mapper (ODM) for MongoDB written in Ruby.
-  * [Ohm](https://github.com/soveran/ohm) - Object-Hash Mapping for Redis
-
+* Auditing
+  * [ActsAsParanoid](https://github.com/ActsAsParanoid/acts_as_paranoid) - ActiveRecord plugin allowing you to hide and restore records without actually deleting them.
+  * [Audited](https://github.com/collectiveidea/audited) - Audited is an ORM extension for ActiveRecord & MongoMapper that logs all changes to your models.
+  * [Destroyed At](https://github.com/dockyard/ruby-destroyed_at) - Allows you to "destroy" an object without deleting the record or associated records.
+  * [Espinita](https://github.com/continuum/espinita) - Audit activerecord models like a boss.
+  * [marginalia](https://github.com/basecamp/marginalia) - Attach comments to your ActiveRecord queries. By default, it adds the application, controller, and action names as a comment at the end of each query.
+  * [mongoid-history](https://github.com/aq1018/mongoid-history) - Multi-user non-linear history tracking, auditing, undo, redo for mongoid.
+  * [PaperTrail](https://github.com/airblade/paper_trail) - Track changes to your ActiveRecord models' data for auditing or versioning.
+  * [Paranoia](https://github.com/rubysherpas/paranoia) - A re-implementation of acts_as_paranoid for Rails 3 and 4, using much, much, much less code.
+  * [PermenantRecords](https://github.com/JackDanger/permanent_records) - Soft-delete your ActiveRecord records, like an explicit version of ActsAsParanoid.
+* Import
+  * [ActiveImporter](https://github.com/continuum/active_importer) - Define importers that load tabular data from spreadsheets or CSV files into any ActiveRecord-like ORM.
+  * [data_miner](https://github.com/seamusabshere/data_miner) - Download, pull out of a ZIP/TAR/GZ/BZ2 archive, parse, correct, and import XLS, ODS, XML, CSV, HTML, etc. into your ActiveRecord models.
+  * [ferry](https://github.com/cmu-is-projects/ferry) - A ruby gem for easy data transfer.
+* Misc
+  * [ActiveRecord::Turntable](https://github.com/drecom/activerecord-turntable) - A database sharding extension for ActiveRecord.
+  * [ActiveValidators](https://github.com/franckverrot/activevalidators) - An exhaustive collection of off-the-shelf and tested ActiveModel/ActiveRecord validations.
+  * [Enumerize](https://github.com/brainspec/enumerize) - Enumerated attributes with I18n and ActiveRecord/Mongoid/MongoMapper support.
+  * [Goldiloader](https://github.com/salsify/goldiloader) - Automatic ActiveRecord eager loading.
+  * [mini_record](https://github.com/DAddYE/mini_record) - ActiveRecord meets DataMapper, with MiniRecord you are be able to write schema inside your models.
+* Multi-tenancy
+  * [Acts As Tennant](https://github.com/ErwinM/acts_as_tenant) - Add multi-tenancy to a Rails app through a shared database strategy.
+  * [Apartment](https://github.com/influitive/apartment) - Multi-tenancy for Rails and ActiveRecord.
+* Social
+  * [Acts As Commentable](https://github.com/jackdempsey/acts_as_commentable) - Provides a single Comment model that can be attached to any model(s) within your app.
+  * [Acts As Commentable with Threading](https://github.com/elight/acts_as_commentable_with_threading) - Similar to acts_as_commentable; however, utilizes awesome_nested_set to provide threaded comments.
+  * [acts_as_follower](https://github.com/tcocca/acts_as_follower) - Allow any ActiveRecord model to follow any other model.
+  * [ActiveRecord Reputation System](https://github.com/twitter/activerecord-reputation-system) - An Active Record Reputation System for Rails.
+  * [ActsAsTaggableOn](https://github.com/mbleigh/acts-as-taggable-on) - A tagging plugin for ActiveRecord that allows for custom tagging along dynamic contexts.
+  * [Acts As Votable](https://github.com/ryanto/acts_as_votable) - Allow any ActiveRecord model to be voted on, like/dislike, upvote/downvote, etc.
+  * [Merit](https://github.com/merit-gem/merit) - Adds reputation behavior to Rails apps in the form of Badges, Points, and Rankings for ActiveRecord or Mongoid.
+  * [PublicActivity](https://github.com/chaps-io/public_activity) - Provides easy activity tracking for your ActiveRecord, Mongoid 3 and MongoMapper models in Rails 3 and 4. Similar to Github's Public Activity.
+  * [Unread](https://github.com/ledermann/unread) - Manage read/unread status of ActiveRecord objects - and it's fast.
+* Sorting
+  * [ActsAsList](https://github.com/swanandp/acts_as_list) - Provides the capabilities for sorting and reordering a number of objects in a list.
+  * [ranked-model](https://github.com/mixonic/ranked-model) - A modern row sorting library for ActiveRecord. It uses ARel aggressively and is better optimized than most other libraries.
+* Tree
+  * [ActsAsTree](https://github.com/amerine/acts_as_tree) - Extends ActiveRecord to add simple support for organizing items into parent–children relationships.
+  * [Ancestry](https://github.com/stefankroes/ancestry) - Organise ActiveRecord model into a tree structure using a variation on the materialised path pattern.
+  * [Awesome Nested Set](https://github.com/collectiveidea/awesome_nested_set) - Awesome Nested Set is an implementation of the nested set pattern for ActiveRecord models.
+  * [Closure Tree](https://github.com/mceachen/closure_tree) - Easily and efficiently make your ActiveRecord models support hierarchies using a Closure Table.
+  * [Mongoid Tree](https://github.com/benedikt/mongoid-tree) - A tree structure for Mongoid documents using the materialized path pattern.
 
 ## Package Management
 
-*Libraries for package and dependency management.*
+* Gems
+  * [Bundler](http://bundler.io) - Manage your application's gem dependencies with less pain.
+  * [RubyGems](https://rubygems.org) - Community's gem hosting service.
+* Packages and Applications
+  * [Berkshelf](https://github.com/berkshelf/berkshelf) - A Chef Cookbook manager.
+  * [CocoaPods](https://github.com/CocoaPods/CocoaPods) - The Objective-C dependency manager.
+  * [fpm](https://github.com/jordansissel/fpm) - Effing package management! Build packages for multiple platforms (deb, rpm, etc) with great ease and sanity.
+  * [Linuxbrew](https://github.com/Homebrew/linuxbrew) - A fork of Homebrew for Linux.
+  * [Homebrew-cask](https://github.com/caskroom/homebrew-cask) - A CLI workflow for the administration of Mac applications distributed as binaries.
+  * [Homebrew](https://github.com/Homebrew/homebrew) - The missing package manager for OS X.
 
-  * [RubyGems](https://rubygems.org/) - RubyGems is a package manager for the Ruby programming language that provides a standard format for distributing Ruby programs and libraries
-  * [Bundler](http://bundler.io) - Bundler provides a consistent environment for Ruby projects by tracking and installing the exact gems and versions that are needed
-  * [Homebrew](http://brew.sh) - Homebrew installs the stuff you need that Apple didn’t
-  * [Homebrew Cask](http://caskroom.io/) - Cask provides a friendly homebrew-style CLI workflow for the administration of Mac applications distributed as binaries
-  
 ## Pagination
 
-  * [kaminari](https://github.com/amatsuda/kaminari) A Scope & Engine based, clean, powerful, customizable and sophisticated paginator
-  * [will_paginate](https://github.com/mislav/will_paginate) Pagination library for Rails 3, Sinatra, Merb, DataMapper, and more
-  * [order_query](https://github.com/glebm/order_query) Keyset pagination to find the next or previous record(s) relative to the current one efficiently, e.g. for infinite scroll.
+* [Kaminari](https://github.com/amatsuda/kaminari) - A Scope & Engine based, clean, powerful, customizable and sophisticated paginator for modern web app frameworks and ORMs.
+* [order_query](https://github.com/glebm/order_query) - A keyset pagination library to find the next or previous record(s) relative to the current one efficiently, e.g. for infinite scroll.
+* [will_paginate](https://github.com/mislav/will_paginate) - A pagination library that integrates with Ruby on Rails, Sinatra, Merb, DataMapper and Sequel.
 
-## PDF Processing
+## PDF
 
-  * [wicked_pdf](https://github.com/mileszs/wicked_pdf) PDF generator (from HTML) plugin for Ruby on Rails
-  * [pdfkit](https://github.com/pdfkit/pdfkit) HTML+CSS to PDF using wkhtmltopdf
-  * [prawn](https://github.com/prawnpdf/prawn) Fast, Nimble PDF Writer for Ruby
+* [CombinePDF](https://github.com/boazsegev/combine_pdf) - A Pure ruby library to merge or stump PDF files, number pages and more.
+* [Gimli](https://github.com/walle/gimli) - Utility for converting markup files to pdf files.
+* [Kitabu](https://github.com/fnando/kitabu) - A framework for creating e-books from Markdown/Textile text markup using Ruby.
+* [Pdfkit](https://github.com/pdfkit/pdfkit) - HTML+CSS to PDF using wkhtmltopdf.
+* [Prawn](https://github.com/prawnpdf/prawn) - Fast, Nimble PDF Writer for Ruby.
+* [RGhost](https://github.com/shairontoledo/rghost) - RGhost is a document creation and conversion API.
+* [Shrimp](https://github.com/adjust/shrimp) - A phantomjs based pdf renderer.
+* [Squid](https://github.com/fullscreen/squid) - Squid · A Ruby library to plot charts in PDF files
+* [Wicked Pdf](https://github.com/mileszs/wicked_pdf) - PDF generator (from HTML) plugin for Ruby on Rails.
+* [Wisepdf](https://github.com/igor-alexandrov/wisepdf) - Wkhtmltopdf wrapper done right.
 
-## Presentation Tools
+## Performance Monitoring
 
-  * [rabbit](https://github.com/rabbit-shocker/rabbit) A programable presentaton tool by Ruby
-  * [reveal-ck](https://github.com/jedcn/reveal-ck) Reveal.js presentations with a Ruby toolset
+* [Instrumental](https://github.com/expectedbehavior/instrumental_agent) - Measure your application in real time with [Instrumental](https://instrumentalapp.com/).
+* [New Relic](https://github.com/newrelic/rpm) - Find and fix Ruby errors with New Relic application monitoring and troubleshooting.
+* [Skylight](https://github.com/skylightio/skylight-ruby) - A smart profiler for your Rails apps that visualizes request performance.
+* [TraceView](https://github.com/appneta/ruby-traceview) -  Full-stack application tracing and brilliant data visualization to build faster, more reliable web apps.
+
+## Presentation Programs
+
+* [Middleman Presentation](https://github.com/fedux-org/middleman-presentation) - Build wonderful presentations based on HTML and JavaScript by using ruby.
+
+## Process Monitoring
+
+* [Bluepill](https://github.com/bluepill-rb/bluepill) - Simple process monitoring tool.
+* [Eye](https://github.com/kostya/eye) - Process monitoring tool. Inspired from Bluepill and God.
+* [God](https://github.com/mojombo/god) - An easy to configure, easy to extend monitoring framework written in Ruby.
 
 ## Processes and Threads
 
-*Libraries for woking with processes or threads*
+* [childprocess](https://github.com/jarib/childprocess) - Cross-platform ruby library for managing child processes.
+* [forkoff](https://github.com/ahoward/forkoff) - brain-dead simple parallel processing for ruby.
+* [Parallel](https://github.com/grosser/parallel) - Run any code in parallel Processes (> use all CPUs) or Threads (> speedup blocking operations).
+Best suited for map-reduce or e.g. parallel downloads/uploads.
+* [posix-spawn](https://github.com/rtomayko/posix-spawn) - Fast Process::spawn for Rubys >= 1.8.7 based on the posix_spawn() system interfaces.
 
-  * [Parallel](https://github.com/grosser/parallel) - Ruby parallel processing made simple and fast
+## Profiler
 
-## Profiling
-
-  * [bullet](https://github.com/flyerhzm/bullet) - help to kill N+1 queries and unused eager loading
-
-## Push Notification
-
-  * [Rpush](https://github.com/rpush/rpush) - The push notification service for Ruby.
-  * [apn_sender](https://github.com/arthurnn/apn_sender) - Background worker to send Apple Push Notifications over a persistent TCP socket.
-  * [Houston](https://github.com/nomad/houston) - A simple gem for sending Apple Push Notifications.
+* [benchmark-ips](https://github.com/evanphx/benchmark-ips) - Provides iteration per second benchmarking for Ruby.
+* [bullet](https://github.com/flyerhzm/bullet) - Help to kill N+1 queries and unused eager loading.
+* [Derailed Benchmarks](https://github.com/schneems/derailed_benchmarks) - A series of things you can use to benchmark any Rack based app.
+* [Peek](https://github.com/peek/peek) - Visual status bar showing Rails performance.
+* [perftools.rb](https://github.com/tmm1/perftools.rb) - gperftools (formerly known as google-perftools) for Ruby code.
+* [rack-mini-profiler](https://github.com/MiniProfiler/rack-mini-profiler) - Profiler for your development and production Ruby rack apps.
+* [Rbkit](https://github.com/code-mancers/rbkit) - profiler for Ruby. With a GUI.
+* [ruby-prof](https://github.com/ruby-prof/ruby-prof) - A code profiler for MRI rubies.
 
 ## Queue
 
-*Libraries for working with event and task queues.*
+* [Backburner](https://github.com/nesquena/backburner) - Backburner is a beanstalkd-powered job queue that can handle a very high volume of jobs.
+* [Bunny](https://github.com/ruby-amqp/bunny) - Bunny is a popular, easy to use, well-maintained Ruby client for RabbitMQ (3.3+).
+* [Delayed::Job](https://github.com/collectiveidea/delayed_job) - Database backed asynchronous priority queue.
+* [March Hare](https://github.com/ruby-amqp/march_hare) - Idiomatic, fast and well-maintained JRuby client for RabbitMQ.
+* [Resque](https://github.com/resque/resque) - A Redis-backed Ruby library for creating background jobs.
+* [Que](https://github.com/chanks/que) - A Ruby job queue that uses PostgreSQL's advisory locks for speed and reliability.
+* [RocketJob](http://rocketjob.io) - Enterprise Batch Processing System focused on performance, scalability, reliability, and visibility of every job in the system. Outgrown existing solutions? Or, start small and scale up later.
+* [Shoryuken](https://github.com/phstc/shoryuken) - A super efficient AWS SQS thread based message processor for Ruby.
+* [Sidekiq](http://sidekiq.org) - A full-featured background processing framework for Ruby. It aims to be simple to integrate with any modern Rails application and much higher performance than other existing solutions.
+* [Sneakers](https://github.com/jondot/sneakers) - A fast background processing framework for Ruby and RabbitMQ.
+* [Sucker Punch](https://github.com/brandonhilkert/sucker_punch) - A single process background processing library using Celluloid. Aimed to be Sidekiq's little brother.
 
-  * [Resque](https://github.com/resque/resque) A Redis-backed Ruby library for creating background jobs, placing them on multiple queues.
-  * [Delayed::Job](https://github.com/tobi/delayed_job) — Database backed asynchronous priority queue.
-  * [Qu](https://github.com/bkeepers/qu) A Ruby library for queuing and processing background jobs.
-  * [Sidekiq](https://github.com/mperham/sidekiq) Simple, efficient background processing for Ruby
+## Rails Application Generators
 
-## RESTful API
+* [Bootstrappers](https://github.com/xdite/bootstrappers) - Bootstrappers generates a base Rails app using Bootstrap template and other goodies.
+* [Hobo](https://github.com/Hobo/hobo) - The web app builder for Rails.
+* [orats](https://github.com/nickjj/orats) - Opinionated rails application templates.
+* [Rails Composer](https://github.com/RailsApps/rails-composer) - The Rails generator on steroids for starter apps.
+* [Raygun](https://github.com/carbonfive/raygun) - Builds applications with the common customization stuff already done.
+* [Suspenders](https://github.com/thoughtbot/suspenders) - Suspenders is the base Rails application used at thoughtbot.
 
-*Libraries for developing RESTful APIs.*
+## Robotics
 
-  * [Grape](http://intridea.github.io/grape/) - An opinionated micro-framework for creating REST-like APIs in Ruby.
-  * [Rails::API](https://github.com/rails-api/rails-api) - Rails for API only applications
-  * [jbuilder](https://github.com/rails/jbuilder) - Create JSON structures via a Builder-style DSL
-  * [rabl](https://github.com/nesquena/rabl) - General Ruby templating with json, bson, xml, plist and msgpack support
-  * [active_model_serializers](https://github.com/rails-api/active_model_serializers) - ActiveModel::Serializer implementation and Rails hooks
-  * [oat](https://github.com/ismasan/oat) - Adapters-based API serializers with Hypermedia support for Ruby apps (HAL, Siren, JSONAPI).
+* [Artoo](http://artoo.io) - Next generation robotics framework with support for different platforms: Arduino, Leap Motion, Pebble, Raspberry Pi, etc.
 
-## Spreadsheets
+## RSS
 
-*Libraries for manipulating Excel, Google Spreadsheets, Numbers, OpenOffice and LibreOffice files*
-
-  * [spreadsheet](https://github.com/zdavatz/spreadsheet) - The Spreadsheet Library is designed to read and write Spreadsheet Documents.
-  * [axlsx](https://github.com/randym/axlsx) - Axlsx excels at helping you generate beautiful Office Open XML Spreadsheet documents.
-  * [axlsx_rails](https://github.com/straydogstudio/axlsx_rails) - Axlsx_Rails provides an Axlsx renderer so you can move all your spreadsheet code from your controller into view files. 
-  * [roo](https://github.com/roo-rb/roo) - Roo implements read access for all spreadsheet types and read/write access for Google spreadsheets.
-  * [google-spreadsheet-ruby](https://github.com/gimite/google-spreadsheet-ruby) - This is a library to read/write Google Spreadsheet.
-  * [rubyXL](https://github.com/weshatheleopard/rubyXL) - rubyXL is a gem which allows the parsing, creation, and manipulation of Microsoft Excel (.xlsx/.xlsm) Documents
-  * [Odf-report](https://github.com/sandrods/odf-report) - Generates ODF files, given a template (.odt) and data, replacing tags
-  * [simple_xlsx_writer](https://github.com/harvesthq/simple_xlsx_writer) - Just as the name says, simple writter for Office 2007+ Excel files
-  * [remote_table](https://github.com/seamusabshere/remote_table) - Open local or remote XLSX, XLS, ODS, CSV (comma separated), TSV (tab separated), other delimited, fixed-width files, and Google Docs.
-  * [acts_as_xlsx](https://github.com/randym/acts_as_xlsx) - acts_as_xlsx lets you turn any ActiveRecord::Base inheriting class into an excel spreadsheet.
-  * [activeadmin-axlsx](https://github.com/randym/activeadmin-axlsx) - This gem uses axlsx to provide excel/xlsx downloads for resources in Active Admin.
-  * [to_spreadsheet](https://github.com/glebm/to_spreadsheet) - Render XLSX from Rails using existing views
-  * [write_xlsx](https://github.com/cxn03651/write_xlsx) - write_xlsx is a gem to create a new file in the Excel 2007+ XLSX format.
-  * [excel_rails](https://github.com/asanghi/excel_rails) - Allows you to program spreadsheets using .rxls views
-  * [sheets](https://github.com/bspaulding/Sheets) - Work with spreadsheets easily in a native ruby format.
-  * [workbook](https://github.com/murb/workbook) - Workbook contains workbooks, as in a table, contains rows, contains cells, reads/writes excel, ods and csv and tab separated files...
-  * [Spreadsheet report](https://github.com/gnoso/spreadsheet_report) - Simple tool for running queries against ActiveRecord and putting them into a Google Spreadsheet.
-  * [oxcelix](https://github.com/gbiczo/oxcelix) - A fast Excel 2007/2010 (.xlsx) file parser that returns a collection of Matrix objects
-  * [wrap_excel](https://github.com/tomiacannondale/wrap_excel) - WrapExcel is to wrap the win32ole, and easy to use Excel operations with ruby. Detailed description please see the README.
-  * [write_xlsx_rails](https://github.com/maxd/write_xlsx_rails) - xlsx renderer for Rails base on write_xlsx gem
+* [Feed normalizer](https://github.com/aasmith/feed-normalizer) - Extensible Ruby wrapper for Atom and RSS parsers.
+* [Feedjira](https://github.com/feedjira/feedjira) - A feed fetching and parsing library.
+* [Ratom](https://github.com/seangeo/ratom) - A fast, libxml based, Ruby Atom library.
+* [Simple rss](https://github.com/cardmagic/simple-rss) - A simple, flexible, extensible, and liberal RSS and Atom reader.
+* [Stringer](https://github.com/swanson/stringer) - A self-hosted, anti-social RSS reader.
 
 ## Scheduling
 
-  * [whenever](https://github.com/javan/whenever) Cron jobs in Ruby
-  * [resque-scheduler](https://github.com/resque/resque-scheduler) A light-weight job scheduling system built on top of resque
-  * [rufus-scheduler](https://github.com/jmettraux/rufus-scheduler) Scheduler for Ruby
-  * [Clockwork](https://github.com/tomykaira/clockwork) Clockwork is a cron replacement. It runs as a lightweight, long-running Ruby process which sits alongside your web processes (Mongrel/Thin) and your worker processes (DJ/Resque/Minion/Stalker) to schedule recurring work at particular times or dates.
+* [Clockwork](https://github.com/tomykaira/clockwork) - Clockwork is a cron replacement. It runs as a lightweight, long-running Ruby process which sits alongside your web processes (Mongrel/Thin) and your worker processes (DJ/Resque/Minion/Stalker) to schedule recurring work at particular times or dates.
+* [minicron](https://github.com/jamesrwhite/minicron) - A system to manage and monitor cron jobs.
+* [resque-scheduler](https://github.com/resque/resque-scheduler) - A light-weight job scheduling system built on top of Resque.
+* [rufus-scheduler](https://github.com/jmettraux/rufus-scheduler) - Job scheduler for Ruby (at, cron, in and every jobs).
+* [Whenever](https://github.com/javan/whenever) - A Ruby gem that provides a clear syntax for writing and deploying cron jobs.
 
-## Science and Data Analysis
+## Scientific
 
-*Libraries for scientific computing and data analyzing.*
+* Artificial intelligence
+  * [AI4R](https://github.com/sergiofierens/ai4r) - Algorithms covering several Artificial intelligence fields.
+  * [ruby-fann](https://github.com/tangledpath/ruby-fann) - Ruby library for interfacing with FANN (Fast Artificial Neural Network).
+* Bindings
+  * [ruby-opencv](https://github.com/ruby-opencv/ruby-opencv) - An OpenCV wrapper for Ruby.
+* Classifiers
+  * [classifier-reborn](https://github.com/jekyll/classifier-reborn) - An active fork of Classifier, and general module to allow Bayesian and other types of classifications.
+  * [stuff-classifier](https://github.com/alexandru/stuff-classifier) - A library for classifying text into multiple categories.
+* Data analysis/structures
+  * [daru](https://github.com/v0dro/daru) - A library for storage, analysis, manipulation and visualization of data in pure Ruby.
+  * [Rgl](https://github.com/monora/rgl) - A framework for graph data structures and algorithms.
+* Numerical arrays
+  * [NMatrix](https://github.com/sciruby/nmatrix) - Fast numerical linear algebra library for Ruby.
+  * [NArray](https://github.com/masa16/narray) - N-dimensional Numerical Array for Ruby.
+  * [mdarray](https://github.com/rbotafogo/mdarray) - Multi dimensional array implemented for JRuby inspired by NumPy.
+* [SciRuby](https://github.com/sciruby/sciruby) - Tools for scientific computation in Ruby/Rails.
+  * [statsample](https://github.com/sciruby/statsample) - A suite for basic and advanced statistics on Ruby.
+  * [statsample-timeseries](https://github.com/sciruby/statsample-timeseries) - Bioruby Statsample TimeSeries.
+  * [statsample-glm](https://github.com/sciruby/statsample-glm) - Generalized Linear Models extension for Statsample.
+  * [distribution](https://github.com/sciruby/distribution) - Statistical Distributions multi library wrapper.
+  * [integration](https://github.com/sciruby/integration) - Numerical integration methods, based on original work by Beng.
+  * [minimization](https://github.com/sciruby/minimization) - Minimization algorithms on pure Ruby.
+  * [publisci](https://github.com/sciruby/publisci) - A toolkit for publishing scientific results to the semantic web.
+  * [plotrb](https://github.com/sciruby/plotrb) - A plotting library in Ruby built on top of Vega and D3.
+  * [rb-gsl](https://github.com/SciRuby/rb-gsl) - A ruby interface to GNU Scientific library, with NMatrix support.
+* Specific
+  * [BioRuby](https://github.com/bioruby/bioruby) - Library for developing bioinformatics software.
+  * [bloomfilter-rb](https://github.com/igrigorik/bloomfilter-rb) - BloomFilter(s) in Ruby: Native counting filter + Redis counting/non-counting filters.
+  * [decisiontree](https://github.com/igrigorik/decisiontree) - A ruby library which implements ID3 (information gain) algorithm for decision tree learning.
+* Utilities
+  * [smarter_csv](https://github.com/tilo/smarter_csv) - Ruby Gem for smarter importing of CSV Files as Array(s) of Hashes.
+  * [algorithms](https://github.com/kanwei/algorithms) - Library with documentation on when to use a particular structure/algorithm.
 
 ## Search
 
-*Libraries and software for indexing and performing search queries on data.*
+* [chewy](https://github.com/toptal/chewy) - High-level Elasticsearch Ruby framework based on the official elasticsearch-ruby client.
+* [elasticsearch-ruby](https://github.com/elastic/elasticsearch-ruby) - Ruby integrations for Elasticsearch.
+* [elastics](https://github.com/printercu/elastics-rb) - Simple ElasticSearch client with support for migrations and ActiveRecord integration.
+* [has_scope](https://github.com/plataformatec/has_scope) - Has scope allows you to easily create controller filters based on your resources named scopes.
+* [Mongoid Search](https://github.com/mauriciozaffari/mongoid_search) - Simple full text search implementation for Mongoid.
+* [pg_search](https://github.com/Casecommons/pg_search) - Builds ActiveRecord named scopes that take advantage of PostgreSQL's full text search.
+* [ransack](https://github.com/activerecord-hackery/ransack/) - Object-based searching.
+* [Rroonga](https://github.com/ranguba/rroonga) - The Ruby bindings of Groonga.
+* [SearchCop](https://github.com/mrkamel/search_cop) - Extends your ActiveRecord models to support fulltext search engine like queries via simple query strings and hash-based queries.
+* [Searchkick](https://github.com/ankane/searchkick) - Searchkick learns what your users are looking for. As more people search, it gets smarter and the results get better. It’s friendly for developers - and magical for your users.
+* [Searchlogic](https://github.com/binarylogic/searchlogic) - Object based searching, common named scopes, and other useful named scope tools for ActiveRecord.
+* [Sunspot](https://github.com/sunspot/sunspot) - A Ruby library for expressive, powerful interaction with the Solr search engine.
+* [textacular](https://github.com/textacular/textacular) - Exposes full text search capabilities from PostgreSQL, and allows you to declare full text indexes. Textacular extends ActiveRecord with named_scope methods making searching easy and fun!
+* [Thinking Sphinx](https://github.com/pat/thinking-sphinx) - A library for connecting ActiveRecord to the Sphinx full-text search tool.
 
-  * [Thinking Sphinx](https://github.com/pat/thinking-sphinx) - Sphinx plugin for ActiveRecord/Rails
-  * [elasticsearch-ruby](https://github.com/elastic/elasticsearch-ruby) - Ruby integrations for Elasticsearch
-  * [Searchkick](https://github.com/ankane/searchkick) - Intelligent search made easy
-  * [PgSearch](https://github.com/Casecommons/pg_search) - PostgreSQL's full text search
-  * [Rroonga](https://github.com/ranguba/rroonga) - The Ruby bindings of Groonga
-  * [Sunspot](https://github.com/sunspot/sunspot) - Solr-powered search for Ruby objects
+## Security
 
-## Site Monitoring
+* [bundler-audit](https://github.com/rubysec/bundler-audit) - Patch-level security verification for Bundler.
+* [Gitrob](https://github.com/michenriksen/gitrob) - Reconnaissance tool for GitHub organizations.
+* [Metasploit](https://github.com/rapid7/metasploit-framework) - World's most used penetration testing software.
+* [Rack::Attack](https://github.com/kickstarter/rack-attack) - Rack middleware for blocking & throttling abusive requests.
+* [Rack::Protection](https://github.com/sinatra/rack-protection) - Rack middleware for protecting against typical Web attacks.
+* [RbNaCl](https://github.com/cryptosphere/rbnacl) - Ruby binding to the Networking and Cryptography (NaCl) library.
+* [SecureHeaders](https://github.com/twitter/secureheaders) - Automatically apply several headers that are related to security, including: Content Security Policy (CSP), HTTP Strict Transport Security (HSTS), X-Frame-Options (XFO), X-XSS-Protection, X-Content-Type-Options, X-Download-Options & X-Permitted-Cross-Domain-Policies.
 
-*Libs for analytics, monitoring*
+## SEO
 
-  * [rack-google-analytics](https://github.com/kangguru/rack-google-analytics) Simple Rack middleware for implementing google analytics tracking
-  * [DataDog](https://github.com/DataDog/dogapi-rb) A monitoring service for IT, operations and development teams
-  * [Keen IO](https://github.com/keenlabs/keen-gem) Build analytics features directly into your Ruby apps
+* [FriendlyId](https://github.com/norman/friendly_id) - The "Swiss Army bulldozer" of slugging and permalink plugins for Active Record.
+* [MetaTags](https://github.com/kpumuk/meta-tags) - A gem to make your Rails application SEO-friendly.
+* [SitemapGenerator](https://github.com/kjvarga/sitemap_generator) - A framework-agnostic XML Sitemap generator written in Ruby.
 
-## Static Page Generation
+## Social Networking
 
-  * [jekyll](https://github.com/jekyll/jekyll) A blog-aware, static site generator in Ruby
-  * [middleman](https://github.com/middleman/middleman)
+* [diaspora*](https://github.com/diaspora/diaspora) - A privacy aware, distributed, open source social network.
+* [Discourse](https://github.com/discourse/discourse) - A platform for community discussion. Free, open, simple.
+* [Forem](https://github.com/rubysherpas/forem) - Rails 3 and Rails 4 forum engine.
+* [Mailboxer](https://github.com/mailboxer/mailboxer) - A private message system for Rails applications.
+* [Social Shares](https://github.com/Timrael/social_shares) - A gem to check how many times url was shared in social networks.
 
-## Starter Apps
+## Spreadsheets and Documents
 
-*App templates for creating apps quickly*
+* [AXLSX](https://github.com/randym/axlsx) - An excel xlsx generation library.
+* [Roo](https://github.com/roo-rb/roo) - Implements read access for all spreadsheet types and read/write access for Google spreadsheets.
+* [Yomu](https://github.com/Erol/yomu) - Read text and metadata from files and documents (.doc, .docx, .pages, .odt, .rtf, .pdf).
 
-  * [suspenders](https://github.com/thoughtbot/suspenders) A Rails template with our standard defaults, ready to deploy to Heroku
-  * [ruby2-rails4-bootstrap-heroku](https://github.com/diowa/ruby2-rails4-bootstrap-heroku) A starter application based on Ruby 2, Rails 4 and Bootstrap for Sass, deployable on Heroku
-  * [rails-bootstrap](https://github.com/RailsApps/rails-bootstrap) Rails 4.1 starter app with the Bootstrap front-end framework
-  * [rails4-starterkit](https://github.com/starterkits/rails4-starterkit) Rails 4.1 starter app with production ready performance, security, and authentication
-  * [cybele](https://github.com/lab2023/cybele) - Rails 4.x template with responder, simple form, haml, exception notification, etc ...
+## State Machines
 
-## Text Processing
+* [AASM](https://github.com/aasm/aasm) - State machines for Ruby classes (plain Ruby, Rails Active Record, Mongoid).
+* [FiniteMachine](https://github.com/peter-murach/finite_machine) - A plain Ruby state machine with a straightforward and expressive syntax.
+* [simple_states](https://github.com/svenfuchs/simple_states) - A super-slim statemachine-like support library.
+* [Statesman](https://github.com/gocardless/statesman) - A statesmanlike state machine library.
+* [transitions](https://github.com/troessner/transitions) - A ruby state machine implementatio.
+* [Workflow](https://github.com/geekq/workflow) - A finite-state-machine-inspired API for modeling and interacting with what we tend to refer to as 'workflow'.
 
-*Libraries for parsing and manipulating texts.*
+## Static Site Generation
 
-  * General
-
-  * Specific Formats
-
-  * Parser
-
-    * [Yomu](https://github.com/Erol) - Read text and metadata from files and documents (.doc, .docx, .pages, .odt, .rtf, .pdf)
-
-## Tagging
-
-*Libraries for tagging items.*
-
-  * [acts-as-taggable-on](https://github.com/mbleigh/acts-as-taggable-on) - A tagging plugin for Rails applications that allows for custom tagging along dynamic contexts.
+* [High Voltage](https://github.com/thoughtbot/high_voltage) - Easily include static pages in your Rails app.
+* [Jekyll](http://jekyllrb.com) - Transform your plain text into static websites and blogs.
+* [Middleman](https://middlemanapp.com/) - A static site generator using all the shortcuts and tools in modern web development.
+* [Nanoc](http://nanoc.ws/) - A static site generator, fit for building anything from a small personal blog to a large corporate web site.
+* [Octopress](https://github.com/octopress/octopress) - Octopress is an obsessively designed toolkit for writing and deploying Jekyll blogs.
+* [webgen](http://webgen.gettalong.org) - webgen is a fast, powerful and extensible static website generator.
 
 ## Template Engine
 
-*Libraries and tools for templating and lexing.*
-
-  * [Slim](https://github.com/slim-template/slim) A templating lang that reduce the syntax to the essential parts without becoming cryptic.
-    * [slim-rails](https://github.com/slim-template/slim-rails) Rails port of Slim lang
-  * [Haml](https://github.com/haml/haml) HTML Abstraction Markup Language - A Markup Haiku
-    * [haml-rails](https://github.com/indirect/haml-rails) Rails port of Haml lang
-  * [Tilt](https://github.com/rtomayko/tilt)
-  * [Liquid](https://github.com/Shopify/liquid)
+* [Curly](https://github.com/zendesk/curly) - A template language that completely separates structure and logic.
+* [Haml](https://github.com/haml/haml) - HTML Abstraction Markup Language.
+* [Liquid](https://github.com/Shopify/liquid) - Safe, customer facing template language for flexible web apps.
+* [Mustache](https://github.com/mustache/mustache) - Logic-less Ruby templates.
+* [Slim](https://github.com/slim-template/slim) - A template language whose goal is reduce the syntax to the essential parts without becoming cryptic.
+* [Tilt](https://github.com/rtomayko/tilt) - Generic interface to multiple Ruby template engines.
 
 ## Testing
 
-*Libraries for testing codebases and generating test data.*
-
-  * Testing Frameworks
-    * [RSpec](http://rspec.info/) - BDD for Ruby
-    * [MiniTest](https://github.com/seattlerb/minitest) - minitest provides a complete suite of testing facilities supporting TDD, BDD, mocking, and benchmarking
-    * [Cucumber]
-       * [Cucumber Github](https://github.com/cucumber/cucumber/wiki) - Cucumber is a tool that executes plain-text functional descriptions as automated tests
-       * [Cucumber Site](https://cucumber.io/) - Behaviour Driven Development with elegacy and joy
-    * [Spinach](https://github.com/codegram/spinach) - Spinach is a high-level BDD framework that leverages the expressive Gherkin language (used by Cucumber) to help you define executable specifications of your application or library's acceptance criteria.
-    * [Rubytest](http://rubyworks.github.io/rubytest) - Rubytest is a testing metaframework usedful for create highly customize test suites or building whole new test frameworks.
-       * [BRASS](http://rubyworks.github.io/brass) - Bare-metal Ruby assertion system standard used by Rubytest.
-       * [Lemon](http://rubyworks.github.io/lemon) - Strict unit test system built on top of Rubytest.
-    * [shoulda-matchers](https://github.com/thoughtbot/shoulda-matchers) - Collection of testing matchers extracted from Shoulda
-    * [capybara](https://github.com/jnicklas/capybara) - Acceptance test framework for web applications
-  * Mock
-    * [RSpec-mocks](https://github.com/rspec/rspec-mocks) - RSpec's 'test double' framework, with support for stubbing and mocking
-    * [Mocha](http://gofreerange.com/mocha/docs/) - Mocking and stubbing library with JMock/SchMock syntax, which allows mocking and stubbing of methods on real (non-mock) classes.
-    * [FlexMock](https://github.com/jimweirich/flexmock) - Flexible mocking for Ruby testing
-  * Fake Data
-    * [Faker](https://github.com/stympy/faker) - A library for generating fake data such as names, addresses, and phone numbers
-    * [ffaker](https://github.com/ffaker/ffaker) - Faker Refactored.
-    * [Forgery](https://github.com/sevenwire/forgery) - Easy and customizable generation of forged data.
-  * Code Coverage
-    * [simplecov](https://github.com/colszowka/simplecov) Code coverage for Ruby 1.9+ with a powerful configuration library and automatic merging of coverage
-  * Load Testing
-
-  * Error Handler
+* Frameworks
+  * [RSpec](https://github.com/rspec/rspec) - Behaviour Driven Development for Ruby.
+    * Formatters
+      * [Emoji-RSpec](https://github.com/cupakromer/emoji-rspec) - Custom Emoji Formatters for RSpec.
+      * [Fuubar](https://github.com/thekompanee/fuubar) - The instafailing RSpec progress bar formatter.
+      * [Nyan Cat](https://github.com/mattsears/nyan-cat-formatter) - Nyan Cat inspired RSpec formatter!
+  * [Aruba](https://github.com/cucumber/aruba) - Testing command line applications with cucumber and rspec.
+  * [Bacon](https://github.com/chneukirchen/bacon) - A small RSpec clone.
+  * [Capybara](http://jnicklas.github.io/capybara) - Acceptance test framework for web applications.
+  * [Cucumber](https://github.com/cucumber/cucumber) - BDD that talks to domain experts first and code second.
+  * [Cutest](https://github.com/djanowski/cutest) - Isolated tests in Ruby.
+  * [Howitzer](https://github.com/strongqa/howitzer) - Ruby based framework for acceptance testing
+  * [Konacha](https://github.com/jfirebaugh/konacha) - Test your Rails application's JavaScript with the mocha test framework and chai assertion library.
+  * [minitest](https://github.com/seattlerb/minitest) - minitest provides a complete suite of testing facilities supporting TDD, BDD, mocking, and benchmarking.
+  * [RR](https://github.com/rr/rr) - A test double framework that features a rich selection of double techniques and a terse syntax.
+  * [shoulda-matchers](https://github.com/thoughtbot/shoulda-matchers) - Provides Test::Unit- and RSpec-compatible one-liners that test common Rails functionality. These tests would otherwise be much longer, more complex, and error-prone.
+  * [Spinach](https://github.com/codegram/spinach) - Spinach is a high-level BDD framework that leverages the expressive Gherkin language (used by Cucumber) to help you define executable specifications of your application or library's acceptance criteria.
+  * [Spork](https://github.com/sporkrb/spork) - A DRb server for testing frameworks (RSpec / Cucumber currently).
+  * [Test::Unit](http://test-unit.github.io) - Test::Unit is a xUnit family unit testing framework for Ruby.
+* Fake Data
+  * [Fabrication](http://www.fabricationgem.org) - A simple and powerful object generation library.
+  * [factory_girl](https://github.com/thoughtbot/factory_girl) - A library for setting up Ruby objects as test data.
+  * [Fake Person](https://github.com/adamcooke/fake-person) - Uses some of the most popular given & surnames in the US & UK.
+  * [faker](https://github.com/stympy/faker) - A library for generating fake data such as names, addresses, and phone numbers.
+  * [ffaker](https://github.com/ffaker/ffaker) - A faster Faker, generates dummy data, rewrite of faker.
+  * [Forgery](https://github.com/sevenwire/forgery) - Easy and customizable generation of forged data.
+  * [Machinist](https://github.com/notahat/machinist) - Fixtures aren't fun. Machinist is.
+* Mock
+  * [ActiveMocker](https://github.com/zeisler/active_mocker) - Generate mocks from ActiveRecord models for unit tests that run fast because they don’t need to load Rails or a database.
+  * [TestXml](https://github.com/alovak/test_xml) - TestXml is a small extension for testing XML/HTML.
+  * [WebMock](https://github.com/bblimke/webmock) - Library for stubbing and setting expectations on HTTP requests.
+* WebDrivers
+  * [Selenium WebDriver](http://selenium.googlecode.com/git/docs/api/rb/index.html) - This gem provides Ruby bindings for WebDriver.
+  * [API Taster](https://github.com/fredwu/api_taster) - A quick and easy way to visually test your Rails application's API.
+  * [Poltergeist](https://github.com/teampoltergeist/poltergeist) - A PhantomJS driver for Capybara.
+  * [Watir](https://github.com/watir/watir/) - Web application testing in Ruby.
+* Extra
+  * [Appraisal](https://github.com/thoughtbot/appraisal) - Appraisal integrates with bundler and rake to test your library against different versions of dependencies.
+  * [Parallel Tests](https://github.com/grosser/parallel_tests) - Speedup Test::Unit + RSpec + Cucumber by running parallel on multiple CPUs (or cores).
+  * [Ruby-JMeter](https://github.com/flood-io/ruby-jmeter) - A Ruby based DSL for building JMeter test plans.
+  * [Spring](https://github.com/rails/spring) - Preloads your rails environment in the background for faster testing and Rake tasks.
+  * [timecop](https://github.com/travisjeffery/timecop) - Provides "time travel" and "time freezing" capabilities, making it dead simple to test time-dependent code.
+  * [vcr](https://github.com/vcr/vcr) - Record your test suite's HTTP interactions and replay them during future test runs for fast, deterministic, accurate tests.
+  * [Zapata](https://github.com/Nedomas/zapata) - Who has time to write tests? This is a revolutionary tool to make them write themselves.
+  * [Wrong](https://github.com/sconover/wrong) - Wrong provides a general assert method that takes a predicate block. Assertion failure messages are rich in detail.
 
 ## Third-party APIs
 
-*Libraries for accessing third party APIs.*
-
-  * [koala](https://github.com/arsduo/koala) A lightweight, flexible library for Facebook
-  * [fb_graph](https://github.com/nov/fb_graph) A full-stack Facebook Graph API wrapper
-  * [twitter](https://github.com/sferik/twitter) A Ruby interface to the Twitter API
-  * [tweetstream](https://github.com/tweetstream/tweetstream) A simple library for consuming Twitter's Streaming API
-  * [gitlab](https://github.com/NARKOZ/gitlab) Ruby wrapper and CLI for the GitLab API
-  * [octokit.rb](https://github.com/octokit/octokit.rb) Ruby toolkit for the GitHub API
-  * [instagram](https://github.com/Instagram/instagram-ruby-gem) The official gem for the Instagram API
-  * [linkedin](https://github.com/hexgnu/linkedin) Ruby wrapper for the LinkedIn API
-  * [twilio-ruby](https://github.com/twilio/twilio-ruby) A Ruby gem for communicating with the Twilio API and generating TwiML
-  * [viewpoint-spws](https://github.com/zenchild/viewpoint-spws) A Microsoft Sharepoint Web Services library for Ruby.
-  * [youtube_it](https://github.com/kylejginavan/youtube_it) An object-oriented Ruby wrapper for the YouTube GData API
-  * [flickraw](https://github.com/hanklords/flickraw) Flickraw is a library to access flickr api
-  * [f00px](https://github.com/500px/f00px) Official 500px api ruby gem
-  * [rspotify](https://github.com/guilhermesad/rspotify) Ruby wrapper for the Spotify Web API
-
-## URL Manipulation
-
-*Libraries for parsing URLs.*
+* [databasedotcom](https://github.com/heroku/databasedotcom) - Ruby client for the Salesforce's Database.com and Chatter APIs.
+* [Dropbox](https://github.com/futuresimple/dropbox-api) - Dropbox API Ruby Client.
+* [facy](https://github.com/huydx/facy) - Command line power tool for facebook.
+* [fb_graph](https://github.com/nov/fb_graph) - A full-stack Facebook Graph API wrapper.
+* [flickr](https://github.com/RaVbaker/flickr) - A Ruby interface to the Flickr API.
+* [gitlab](https://github.com/NARKOZ/gitlab) - Ruby wrapper and CLI for the GitLab API.
+* [gmail](https://github.com/gmailgem/gmail) - A Rubyesque interface to Gmail, with all the tools you'll need.
+* [hipchat-rb](https://github.com/hipchat/hipchat-rb) - HipChat HTTP API Wrapper in Ruby with Capistrano hooks.
+* [instagram-ruby-gem](https://github.com/Instagram/instagram-ruby-gem) - The official gem for the Instagram REST and Search APIs.
+* [itunes_store_transporter](https://github.com/sshaw/itunes_store_transporter) - Ruby wrapper around Apple's iTMSTransporter program.
+* [linkedin](https://github.com/hexgnu/linkedin) - Provides an easy-to-use wrapper for LinkedIn's REST APIs.
+* [Octokit](http://octokit.github.io/octokit.rb) - Ruby toolkit for the GitHub API.
+* [Pusher](https://github.com/pusher/pusher-http-ruby) - Ruby server library for the Pusher API.
+* [ruby-gmail](https://github.com/dcparker/ruby-gmail) - A Rubyesque interface to Gmail.
+* [ruby-trello](https://github.com/jeremytregunna/ruby-trello) - Implementation of the Trello API for Ruby.
+* [Slack Notifier](https://github.com/stevenosloan/slack-notifier) - A simple wrapper for posting to Slack channels.
+* [Slack ruby gem](https://github.com/aki017/slack-ruby-gem) - A Ruby wrapper for the Slack API.
+* [soundcloud-ruby](https://github.com/soundcloud/soundcloud-ruby) - Official SoundCloud API Wrapper for Ruby.
+* [t](https://github.com/sferik/t) - A command-line power tool for Twitter.
+* [tweetstream](https://github.com/tweetstream/tweetstream) - A simple library for consuming Twitter's Streaming API.
+* [twilio-ruby](https://github.com/twilio/twilio-ruby) - A module for using the Twilio REST API and generating valid TwiML.
+* [twitter](https://github.com/sferik/twitter) - A Ruby interface to the Twitter API.
+* [wikipedia](https://github.com/kenpratt/wikipedia-client) - Ruby client for the Wikipedia API.
+* [Yt](https://github.com/Fullscreen/yt) - An object-oriented Ruby client for YouTube API V3.
 
 ## Video
 
-*Libraries for manipulating video and GIFs.*
-
-  * [streamio-ffmpeg](https://github.com/streamio/streamio-ffmpeg) Simple yet powerful ruby ffmpeg wrapper for reading metadata and transcoding movies
-
-## Web Content Extracting
-
-*Libraries for extracting web contents.*
+* [Streamio FFMPEG](https://github.com/streamio/streamio-ffmpeg) - Simple yet powerful wrapper around the ffmpeg command for reading metadata and transcoding movies.
 
 ## Web Crawling
 
-*Libraries for scraping websites.*
-
-  * [upton](https://github.com/propublica/upton) A batteries-included framework for easy web-scraping
-  * [metainspector](https://github.com/jaimeiniesta/metainspector)
+* [anemone](https://github.com/chriskite/anemone) - Ruby library and CLI for crawling websites.
+* [LinkThumbnailer](https://github.com/gottfrois/link_thumbnailer) - Ruby gem that generates thumbnail images and videos from a given URL. Much like popular social website with link preview.
+* [Mechanize](https://github.com/sparklemotion/mechanize) - Mechanize is a ruby library that makes automated web interaction easy.
+* [MetaInspector](https://github.com/jaimeiniesta/metainspector) - Ruby gem for web scraping purposes.
+* [Upton](https://github.com/propublica/upton) - A batteries-included framework for easy web-scraping.
+* [Wombat](https://github.com/felipecsl/wombat) - Web scraper with an elegant DSL that parses structured data from web pages.
 
 ## Web Frameworks
 
-*Web development frameworks.*
-
-  * [Ruby On Rails](http://rubyonrails.org/) - Ruby on Rails is a full-stack web framework optimized for programmer happiness and sustainable productivity
-  * [Sinatra](http://www.sinatrarb.com/) - Sinatra is a DSL for quickly creating web applications in Ruby with minimal effort.
-  * [Padrino](http://www.padrinorb.com/) - The Godfather of Sinatra provides a full-stack agnostic framework on top of Sinatra
-  * [Cramp](http://cramp.in/) - Cramp is a fully asynchronous real-time web application framework in Ruby
-  * [Lotus](http://lotusrb.org/) - A newborn complete Ruby web framework that is simple, fast and lightweight.
-  * [Cuba](http://cuba.is/) - Cuba is a microframework for web development originally inspired by Rum, a tiny but powerful mapper for Rack applications.
-  * [Pakyow](https://pakyow.com/) - Pakyow is an open-source framework for the modern web. Build working software faster with a development process that remains friendly to both designers and developers. It's built for getting along.
+* [Camping](http://camping.io) - A web microframework which consistently stays at less than 4kB of code.
+* [Cuba](http://cuba.is) - A microframework for web development.
+* [Hobbit](https://github.com/patriciomacadden/hobbit) - A minimalistic microframework built on top of Rack.
+* [Lotus](http://lotusrb.org) - It aims to bring back Object Oriented Programming to web development, leveraging on a stable API, a minimal DSL, and plain objects.
+* [Padrino](http://www.padrinorb.com) - A full-stack ruby framework built upon Sinatra.
+* [Pakyow](https://pakyow.com/) - A framework for building modern web-apps in Ruby. It helps you build working software faster with a development process that remains friendly to both designers and developers.
+* [Ramaze](http://ramaze.net/) - A simple, light and modular open-source web application framework written in Ruby.
+* [Roda](http://roda.jeremyevans.net/) - A routing tree web framework.
+* [Ruby on Rails](http://rubyonrails.org) - A web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
+* [Scorched](http://scorchedrb.com) - Light-weight, inheritable and composable web framework, inspired by Sinatra.
+* [Sinatra](http://www.sinatrarb.com) - Classy web-development dressed in a DSL.
+* [Volt](https://github.com/voltrb/volt) - A Ruby web framework where your ruby code runs on both the server and the client.
 
 ## Web Servers
 
-*App server interface*
-
-  * [puma](https://github.com/puma/puma) A simple, fast, threaded, and highly concurrent HTTP 1.1 server for Ruby/Rack applications.
-  * [thin](https://github.com/macournoyer/thin) A thin and fast web server
-  * [trinidad](https://github.com/trinidad/trinidad) Run Rails or Rack applications within an embedded Apache Tomcat container.
-  * [unicorn](https://github.com/defunkt/unicorn) An HTTP server for Rack applications designed to only serve fast clients.
-  * [passenger](https://github.com/phusion/passenger) A modern web server and application server for Ruby, Python and Node.js.
-  * [pow](https://github.com/basecamp/pow) Pow treats files and directories as ruby objects giving you more power and flexibility.
-  * [goliath](https://github.com/postrank-labs/goliath) is a non-blocking Ruby web server framework.
+* [Goliath](https://github.com/postrank-labs/goliath) - A non-blocking Ruby web server framework.
+* [Phusion Passenger](https://www.phusionpassenger.com) - Fast and robust web server and application server.
+* [Puma](https://github.com/puma/puma) - A modern, concurrent web server for Ruby.
+* [Rack](http://rack.github.io) - A common Ruby web server interface. By itself, it's just a specification and utility library, but all Ruby web servers implement this interface.
+* [Reel](https://github.com/celluloid/reel) - Celluloid::IO-powered web server.
+* [Thin](http://code.macournoyer.com/thin/) - Tiny, fast & funny HTTP server.
+* [TorqueBox](https://github.com/torquebox/torquebox) - A Ruby application server built on JBoss AS7 and JRuby.
+* [Unicorn](http://unicorn.bogomips.org) - Rack HTTP server for fast clients and Unix.
 
 ## WebSocket
 
-*Libraries for woking with WebSocket.*
+* [Faye](http://faye.jcoglan.com/ruby.html) - A set of tools for simple publish-subscribe messaging between web clients.
+* [Firehose](https://github.com/polleverywhere/firehose) - Build realtime Ruby web applications.
+* [Rails Realtime](https://github.com/liamks/rails-realtime) - Adding Real-Time To Your RESTful Rails App.
+* [Slanger](https://github.com/stevegraham/slanger) - Open Pusher implementation compatible with Pusher libraries.
+* [Sync](https://github.com/chrismccord/sync) - Real-time Rails Partials.
+* [Websocket-Rails](https://github.com/websocket-rails/websocket-rails) - Creates a built in WebSocket server inside a Rails application with ease, and also support streaming HTTP.
 
-  * [Faye](http://faye.jcoglan.com/ruby.html) - Simple pub/sub messaging for the web
-  * [websocket-rails](https://github.com/websocket-rails/websocket-rails) - Plug and play websocket support for ruby on rails.
+# Services and Apps
 
-# Miscellaneous
+Online tools, services and APIs to simplify development.
 
-*Useful libraries or tools that don't fit in the categories above.*
-
-  * [packetfu](https://github.com/packetfu/packetfu) A mid-level packet manipulation library for Ruby.
-  * [chatterbot](https://github.com/muffinista/chatterbot) A straightforward ruby-based Twitter Bot Framework, using OAuth to authenticate
-  * [sneakers](https://github.com/jondot/sneakers) A fast background processing framework for Ruby and RabbitMQ
-  * [ransack](https://github.com/activerecord-hackery/ransack) Object-based searching.
-  * [cinch](https://github.com/cinchrb/cinch) The IRC Bot Building Framework
-  * [pry](https://github.com/pry/pry) An IRB alternative and runtime developer console
-  * [friendly_id](https://github.com/norman/friendly_id) Slugging and permalink plugins for ActiveRecord
-  * [backup](https://github.com/backup/backup) An elegant DSL in Ruby for performing backups on UNIX-like systems
-  * [kss](https://github.com/kneath/kss) Documenting CSS and generating styleguides
-  * [AASM](https://github.com/aasm/aasm) - A library for adding finite state machines to Ruby classes
-  * [JsonCompare](https://github.com/a2design-inc/json-compare) - Returns the difference between two JSON files
-  * [blankable](https://github.com/lab2023/blankable) - Adds blank slates to index view in Rails
-  * [tcmb_currency](https://github.com/lab2023/tcmb_currency) - T.C.M.B. currencies for Money Gem
-  * [enumerize](https://github.com/brainspec/enumerize) - Enumerated attributes with I18n and ActiveRecord/Mongoid support
-  * [lol_dba](https://github.com/plentz/lol_dba) - lol_dba is a small package of rake tasks that scan your application models and displays a list of columns that probably should be indexed. 
-  * [annotate-models](https://github.com/ctran/annotate_models) - Annotate ActiveRecord models
-  * [fast_attributes](https://github.com/applift/fast_attributes) - FastAttributes adds attributes with their types to the class
-  * [Github Changelog Generator](https://github.com/skywinder/Github-Changelog-Generator) — automatically generate change log from your tags, issues, labels and pull requests on GitHub.
-  * [Letter Opener](https://github.com/ryanb/letter_opener) — Preview email in the default browser instead of sending it.
-  * [Auto HTML](https://github.com/dejan/auto_html) — Transforming URLs to appropriate resource (image, link, YouTube, Vimeo video,...).
-
-
-## Editor Plugins
-
-*Plugins for various editors.*
-
-  * [vim-ruby](https://github.com/vim-ruby/vim-ruby) Vim/Ruby Configuration Files
-  * [vim-rails](https://github.com/tpope/vim-rails) rails.vim: Ruby on Rails power tools
+* [AppSignal](https://appsignal.com) - Better monitoring for your Rails applications.
+* [CodeClimate](https://codeclimate.com) - Quality & security analysis for Ruby on Rails and Javascript.
+* [Gemnasium](https://gemnasium.com) - Monitor your project dependencies and alert you about updates and security vulnerabilities.
+* [GitHub](https://github.com) - Powerful collaboration, code review, and code management for open source and private projects.
+* [Gitlab CI](https://about.gitlab.com/gitlab-ci/) - Integrate with your GitLab to run tests for your projects.
+* [GitLab](https://about.gitlab.com) -  Open source software to collaborate on code.
+* [Hakiri](https://hakiri.io) - Ship Secure Ruby Apps.
+* [HoundCI](https://houndci.com) - Review your Ruby code for style guide violations.
+* [HuBoard](https://huboard.com) - Kanban board for GitHub issues.
+* [Inch CI](http://inch-ci.org/) - Documentation badges for Ruby projects.
+* [Omniref](https://www.omniref.com) - A comprehensive Ruby documentation site.
+* [PR Dashboard](http://prs.crowdint.com/) - Review open Pull Requests from your organizations and leave a "LGTM" comment.
+* [PullReview](https://www.pullreview.com/) - Automated code review for Ruby and Rails - from style to security.
+* [ProfileIt](https://profileit.io) - Live production profiling for Ruby on Rails (always FREE for development).
+* [SemaphoreCI](https://semaphoreci.com/) - Hosted continuous integration and deployment service for open source and private projects.
+* [SideCI](https://www.sideci.com) - Automated Code Review with GitHub PR. - Monitoring Style Violations, Quality, Security, Dependencies.
+* [Traveling Ruby](http://phusion.github.io/traveling-ruby/) - Traveling Ruby lets you create self-contained Ruby app packages for Linux and OS X.
+* [Travis CI.com](https://travis-ci.com) - Take care of running your tests and deploying your private apps.
+* [Travis CI.org](https://travis-ci.org) - A distributed build system for the open source community.
+* [Vexor CI](https://vexor.io) - A distributed cloud web-service for building and testing software, a continuous integration tool for private apps with pay-per-minute billing model.
 
 # Resources
 
-*Where to discover things (libraries, news e.g) about Ruby.*
+Where to discover new Ruby libraries, projects and trends.
 
-  * [The Ruby Toolbox](https://www.ruby-toolbox.com/)
-  * [RubyGems](https://rubygems.org/)
-  * [RubyDaily](http://rubydaily.org) - Community driven news
-  * [Ruby Weekly](http://rubyweekly.com/) - A free, once–weekly e-mail round-up of Ruby news and articles.
-  * [Ruby5](https://ruby5.codeschool.com/) - The latest news in the Ruby and Rails community
-  * [RubyFlow](http://www.rubyflow.com) - Ruby Programming Community Link Blog
-  * [GemBundle](http://www.gembundle.com) - A place to discover new Ruby Gems
-
-## People to Follow
-
-*People in Ruby World*
-
-  * [Yukihiro "Matz" Matsumoto](https://twitter.com/yukihiro_matz) - Creator of Ruby lang
-  * [David Heinemeier Hansson](https://twitter.com/dhh) - Creator of Rails framework
-  * [Koichi Sasada](https://github.com/ko1) - Ruby core committer and the developer of YARV
-  * [Aaron Patterson](http://tenderlovemaking.com/) - Committer to Nokogiri, Ruby, and Ruby on Rails
-  * [Avdi Grimm](http://devblog.avdi.org/) - Host of Ruby Tapas webcasts
-  * [Aman Gupta](http://tmm1.net/)- Ruby core committer
-
+* [GitHub Trending](https://github.com/trending?l=ruby) - Find what repositories the GitHub community is most excited about today.
+* [Green Ruby News](http://greenruby.org) - A feed of fresh links of the week about ruby, javascript, webdev and devops.
+* [Open Source Rails](http://www.opensourcerails.com/) - A gallery of the best open source rack and Ruby on Rails web applications.
+* [Ruby5](https://ruby5.codeschool.com/) - The latest news in the Ruby and Rails community.
+* [Ruby Bookmarks](https://github.com/dreikanter/ruby-bookmarks) - Ruby and Ruby on Rails bookmarks collection.
+* [RubyDaily](http://rubydaily.org) - Community driven news.
+* [RubyFlow](http://www.rubyflow.com) - Ruby Programming Community Link Blog.
+* [Ruby Rouges](https://devchat.tv/ruby-rogues) - Weekly panel discussion about programming, primarily in Ruby.
+* [Ruby Weekly](http://rubyweekly.com) - A free, once–weekly e-mail round-up of Ruby news and articles.
+* [The Ruby Toolbox](https://www.ruby-toolbox.com) - A comprehensive catalog of Ruby and Rails plug-ins, gems, tools and resources for Ruby developers with popularity ratings based on GitHub watchers and Gem downloads.
 
 # Other Awesome Lists
 
-Other amazingly awesome lists can be found in the [awesome-awesomeness](https://github.com/bayandin/awesome-awesomeness) list.
-
+Other amazingly awesome lists can be found in the [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome) list.


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/37signals/pow | https://github.com/basecamp/pow 
https://github.com/Empact/roo | https://github.com/roo-rb/roo 
https://github.com/Shopify/active_merchant | https://github.com/activemerchant/active_merchant 
https://github.com/a2design-company/json-compare | https://github.com/a2design-inc/json-compare 
https://github.com/elasticsearch/elasticsearch-ruby | https://github.com/elastic/elasticsearch-ruby 
https://github.com/elasticsearch/logstash | https://github.com/elastic/logstash 
https://github.com/emmanueloga/ffaker | https://github.com/ffaker/ffaker 
https://github.com/gregbell/active_admin | https://github.com/activeadmin/activeadmin 
https://github.com/magiclabs/alchemy_cms | https://github.com/AlchemyCMS/alchemy_cms 
https://github.com/meskyanichi/backup | https://github.com/backup/backup 
https://github.com/opscode/chef | https://github.com/chef/chef 
https://github.com/tarcieri/http | https://github.com/httprb/http 
https://github.com/titanous/mailman | https://github.com/mailman/mailman 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://celluloid.io | https://celluloid.io/ 
http://cukes.info/ | https://cucumber.io/ 
http://nokogiri.org | http://www.nokogiri.org/ 
http://pakyow.com/ | https://pakyow.com/ 
http://refinerycms.com/ | http://www.refinerycms.com 
http://ruby5.envylabs.com/ | https://ruby5.codeschool.com/ 
http://www.capistranorb.com | http://capistranorb.com/ 
http://www.libgosu.org | https://www.libgosu.org/ 
http://www.vagrantup.com | https://www.vagrantup.com/ 
https://bitbucket.org/ged/ruby-pg | https://bitbucket.org/ged/ruby-pg/wiki/Home 
https://www.rubygems.org | https://rubygems.org/ 
