### PR TITLE
Add OctoLinker browser extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,6 +705,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
   * [Github Changelog Generator](https://github.com/skywinder/Github-Changelog-Generator) — automatically generate change log from your tags, issues, labels and pull requests on GitHub.
   * [Letter Opener](https://github.com/ryanb/letter_opener) — Preview email in the default browser instead of sending it.
   * [Auto HTML](https://github.com/dejan/auto_html) — Transforming URLs to appropriate resource (image, link, YouTube, Vimeo video,...).
+  * [OctoLinker](https://github.com/OctoLinker/browser-extension) - Navigate through projects on GitHub.com efficiently with the OctoLinker browser extension.
 
 
 ## Editor Plugins


### PR DESCRIPTION
Navigate through projects on GitHub.com efficiently with the OctoLinker browser extension.

Most projects consist of many files and third party dependencies. Files are referencing other files and / or dependencies by language specific statements like include or require. Dependencies are most likely declared in a file called manifest e.g. package.json or Gemfile. The OctoLinker browser extension makes these references clickable. No more copy and search.

https://github.com/OctoLinker/browser-extension
## Require

![require](https://cloud.githubusercontent.com/assets/1393946/18116659/016a4972-6f4a-11e6-835a-4efc628bc4a0.gif)
## Gem support

![gem](https://cloud.githubusercontent.com/assets/1393946/18116660/01821188-6f4a-11e6-82ea-6076dfad75de.gif)
