### PR TITLE
Add Addressable

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
 
 ## URL Manipulation
 
-*Libraries for parsing URLs.*
+  * [Addressable](https://github.com/sporkmonger/addressable) Addressable is a replacement for the URI implementation that is part of Ruby's standard library. It more closely conforms to RFC 3986, RFC 3987, and RFC 6570 (level 4), additionally providing support for IRIs and URI templates.
 
 ## Video
 


### PR DESCRIPTION
Add [Addressable](https://github.com/sporkmonger/addressable) (Addressable is a replacement for the URI implementation that is part of Ruby's standard library. It more closely conforms to RFC 3986, RFC 3987, and RFC 6570 (level 4), additionally providing support for IRIs and URI templates.
) to URL Manipulation.