### PR TITLE
Adds APIcasso

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
   * [rabl](https://github.com/nesquena/rabl) - General Ruby templating with json, bson, xml, plist and msgpack support
   * [active_model_serializers](https://github.com/rails-api/active_model_serializers) - ActiveModel::Serializer implementation and Rails hooks
   * [oat](https://github.com/ismasan/oat) - Adapters-based API serializers with Hypermedia support for Ruby apps (HAL, Siren, JSONAPI).
-  * [APIcasso](https://github.com/ErvalhouS/APIcaso) - An abstract API design as a Rails-based mountable engine. RESTfullize your legacy code.
+  * [APIcasso](https://github.com/ErvalhouS/APIcasso) - An abstract API design as a Rails-based mountable engine. RESTfullize your legacy code.
 
 ## Serverless
 * [FaaStRuby](https://faastruby.io) - Serverless Software Development Platform for Ruby and Crystal developers.

--- a/README.md
+++ b/README.md
@@ -508,7 +508,8 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
   * [rabl](https://github.com/nesquena/rabl) - General Ruby templating with json, bson, xml, plist and msgpack support
   * [active_model_serializers](https://github.com/rails-api/active_model_serializers) - ActiveModel::Serializer implementation and Rails hooks
   * [oat](https://github.com/ismasan/oat) - Adapters-based API serializers with Hypermedia support for Ruby apps (HAL, Siren, JSONAPI).
-  
+  * [APIcasso](https://github.com/ErvalhouS/APIcaso) - An abstract API design as a Rails-based mountable engine. RESTfullize your legacy code.
+
 ## Serverless
 * [FaaStRuby](https://faastruby.io) - Serverless Software Development Platform for Ruby and Crystal developers.
 


### PR DESCRIPTION
APIcasso is intended to be used to speed-up development, acting as a full-fledged CRUD JSON API into all your models. It is a route-based abstraction that lets you create, read, list, update or delete any ActiveRecord object in your application. This makes it possible to make CRUD-only applications just by creating functional Rails' models. Access to your application's resources is managed by a .scope JSON object per API key. 