### PR TITLE
Replace Axlsx with Caxlsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,16 +524,16 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
 *Libraries for manipulating Excel, Google Spreadsheets, Numbers, OpenOffice and LibreOffice files*
 
   * [spreadsheet](https://github.com/zdavatz/spreadsheet) - The Spreadsheet Library is designed to read and write Spreadsheet Documents.
-  * [axlsx](https://github.com/randym/axlsx) - Axlsx excels at helping you generate beautiful Office Open XML Spreadsheet documents.
-  * [axlsx_rails](https://github.com/straydogstudio/axlsx_rails) - Axlsx_Rails provides an Axlsx renderer so you can move all your spreadsheet code from your controller into view files.
+  * [caxlsx](https://github.com/caxlsx/caxlsx) - Caxlsx excels at helping you generate beautiful Office Open XML Spreadsheet documents.
+  * [caxlsx_rails](https://github.com/caxlsx/caxlsx_rails) - Axlsx-Rails provides an Axlsx renderer so you can move all your spreadsheet code from your controller into view files.
   * [roo](https://github.com/roo-rb/roo) - Roo implements read access for all spreadsheet types and read/write access for Google spreadsheets.
   * [google-spreadsheet-ruby](https://github.com/gimite/google-spreadsheet-ruby) - This is a library to read/write Google Spreadsheet.
   * [rubyXL](https://github.com/weshatheleopard/rubyXL) - rubyXL is a gem which allows the parsing, creation, and manipulation of Microsoft Excel (.xlsx/.xlsm) Documents
   * [Odf-report](https://github.com/sandrods/odf-report) - Generates ODF files, given a template (.odt) and data, replacing tags
   * [simple_xlsx_writer](https://github.com/harvesthq/simple_xlsx_writer) - Just as the name says, simple writter for Office 2007+ Excel files
   * [remote_table](https://github.com/seamusabshere/remote_table) - Open local or remote XLSX, XLS, ODS, CSV (comma separated), TSV (tab separated), other delimited, fixed-width files, and Google Docs.
-  * [acts_as_xlsx](https://github.com/randym/acts_as_xlsx) - acts_as_xlsx lets you turn any ActiveRecord::Base inheriting class into an excel spreadsheet.
-  * [activeadmin-axlsx](https://github.com/randym/activeadmin-axlsx) - This gem uses axlsx to provide excel/xlsx downloads for resources in Active Admin.
+  * [acts_as_caxlsx](https://github.com/caxlsx/acts_as_caxlsx) - acts_as_caxlsx lets you turn any ActiveRecord::Base inheriting class into an excel spreadsheet.
+  * [activeadmin-caxlsx](https://github.com/caxlsx/activeadmin-caxlsx) - This gem uses caxlsx to provide excel/xlsx downloads for resources in Active Admin.
   * [to_spreadsheet](https://github.com/glebm/to_spreadsheet) - Render XLSX from Rails using existing views
   * [write_xlsx](https://github.com/cxn03651/write_xlsx) - write_xlsx is a gem to create a new file in the Excel 2007+ XLSX format.
   * [excel_rails](https://github.com/asanghi/excel_rails) - Allows you to program spreadsheets using .rxls views


### PR DESCRIPTION
The original Axlsx project is unmaintained. This commit replaces Axlsx
and its related gems with the community maintained forks

Ref: https://github.com/randym/axlsx#notice-moved-to-community-axlsx-organization