### PR TITLE
[html-xml-css-manipulation] add Nokolexbor

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
 *Libraries for working with HTML, XML & CSS.*
 
   * [Nokogiri](http://www.nokogiri.org/)
+  * [Nokolexbor](https://github.com/serpapi/nokolexbor) - High-performance HTML5 parser based on Lexbor, with support for both CSS selectors and XPath.
   * [loofah](https://github.com/flavorjones/loofah) A general library for manipulating and transforming HTML/XML documents and fragments
 
 ## HTTP


### PR DESCRIPTION
Github: https://github.com/serpapi/nokolexbor
Rubygem: https://rubygems.org/gems/nokolexbor

Difference from Nokogiri:
- Meant to be a drop-in replacement for [Nokogiri](https://nokogiri.org/).
- [5.2x faster at parsing HTML and up to 997x faster at CSS selectors than Nokogiri](https://github.com/serpapi/nokolexbor#benchmarks).