### PR TITLE
[Testing] turbo tests & [html-xml-css-manipulation] Nokolexbor

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
 *Libraries for working with HTML, XML & CSS.*
 
   * [Nokogiri](http://www.nokogiri.org/)
+  * [Nokolexbor](https://github.com/serpapi/nokolexbor) - High-performance HTML5 parser based on Lexbor, with support for both CSS selectors and XPath.
   * [loofah](https://github.com/flavorjones/loofah) A general library for manipulating and transforming HTML/XML documents and fragments
 
 ## HTTP

--- a/README.md
+++ b/README.md
@@ -583,6 +583,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
   * Testing Frameworks
     * [RSpec](http://rspec.info/) - BDD for Ruby
     * [MiniTest](https://github.com/seattlerb/minitest) - minitest provides a complete suite of testing facilities supporting TDD, BDD, mocking, and benchmarking
+    * [Turbo Tests](https://github.com/serpapi/turbo_tests) - Run RSpec tests on multiple cores. Like `parallel_tests` but with incremental summarized output.
     * [Cucumber]
        * [Cucumber Github](https://github.com/cucumber/cucumber/wiki) - Cucumber is a tool that executes plain-text functional descriptions as automated tests
        * [Cucumber Site](https://cucumber.io/) - Behaviour Driven Development with elegacy and joy


### PR DESCRIPTION
### Turbo tests
Github: https://github.com/serpapi/turbo_tests
Rubygem: https://rubygems.org/gems/turbo_tests

Allows to run RSpec tests on multiple cores. Like `parallel_tests` but with incremental summarized output. 

### Nokolexbor

Github: https://github.com/serpapi/nokolexbor
Rubygem: https://rubygems.org/gems/nokolexbor

Difference from Nokogiri:

Meant to be a drop-in replacement for [Nokogiri](https://nokogiri.org/).
[5.2x faster at parsing HTML and up to 997x faster at CSS selectors than Nokogiri](https://github.com/serpapi/nokolexbor#benchmarks).

P.S. Sorry, I've screwed a few things and closed #108 PR to avoid duplicating.