### PR TITLE
Add Cloud 66

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Your Pull requests are welcome! Let's make this the awesomest resource for Ruby 
   * [Capistrano](http://capistranorb.com/) - Remote multi-server automation tool
   * [Mina](https://github.com/mina-deploy/mina) Really fast deployer and server automation tool
   * [Nanobox](https://github.com/nanobox-io/nanobox) - A micro-PaaS (μPaaS) for creating consistent, isolated, Ruby environments deployable anywhere https://nanobox.io.
+  * [Cloud 66](https://www.cloud66.com/) - Cloud 66 gives you everything you need to build, deploy, and manage your applications on any cloud without the headache of the “server stuff”.
 
 ## Distribution
 


### PR DESCRIPTION
Please, add Cloud 66 to DevOps category.

- Website: https://www.cloud66.com/
- Help page: https://help.cloud66.com/

What is this Ruby project?
Cloud 66 - DevOps as a service that helps to build, deploy and manage Ruby application on any cloud or server.